### PR TITLE
Actualizar puerto del backend a 8080

### DIFF
--- a/systemd/bascula-backend.service
+++ b/systemd/bascula-backend.service
@@ -7,7 +7,7 @@ Type=simple
 User=pi
 WorkingDirectory=/home/pi/bascula-backend
 Environment="PATH=/home/pi/bascula-backend/venv/bin"
-ExecStart=/home/pi/bascula-backend/venv/bin/uvicorn main:app --host 0.0.0.0 --port 8000 --workers 2
+ExecStart=/home/pi/bascula-backend/venv/bin/uvicorn main:app --host 0.0.0.0 --port 8080 --workers 2
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
## Summary
- configurar el servicio de systemd para que ejecute uvicorn en el puerto 8080

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68deac2a84988326a66e339209be7374