### PR TITLE
feat: prepare miniweb for nm clean installs

### DIFF
--- a/scripts/polkit/10-nm-wifi-scan.pkla
+++ b/scripts/polkit/10-nm-wifi-scan.pkla
@@ -1,0 +1,6 @@
+[Allow WiFi Scan]
+Identity=unix-user:pi
+Action=org.freedesktop.NetworkManager.wifi.scan
+ResultActive=yes
+ResultAny=yes
+ResultInactive=yes

--- a/scripts/polkit/11-nm-network-control.pkla
+++ b/scripts/polkit/11-nm-network-control.pkla
@@ -1,0 +1,6 @@
+[Allow Network Control]
+Identity=unix-user:pi
+Action=org.freedesktop.NetworkManager.settings.modify.system;org.freedesktop.NetworkManager.network-control
+ResultActive=yes
+ResultAny=yes
+ResultInactive=yes

--- a/scripts/smoke-miniweb.sh
+++ b/scripts/smoke-miniweb.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:8080}"
+echo "[smoke] Target: ${BASE_URL}" 
+
+HAS_JQ=1
+if ! command -v jq >/dev/null 2>&1; then
+  HAS_JQ=0
+  echo "[smoke][warn] jq no está instalado, omitiendo validación de JSON estructurado" >&2
+fi
+
+echo "[smoke] GET /openapi.json"
+if [[ "${HAS_JQ}" -eq 1 ]]; then
+  curl -fsS "${BASE_URL}/openapi.json" | jq . >/dev/null
+else
+  curl -fsS "${BASE_URL}/openapi.json" >/dev/null
+fi
+
+echo "[smoke] GET /api/network/status"
+if [[ "${HAS_JQ}" -eq 1 ]]; then
+  curl -fsS "${BASE_URL}/api/network/status" | jq . >/dev/null
+else
+  curl -fsS "${BASE_URL}/api/network/status" >/dev/null
+fi
+
+echo "[smoke] GET /api/miniweb/pin"
+if [[ "${HAS_JQ}" -eq 1 ]]; then
+  curl -fsS "${BASE_URL}/api/miniweb/pin" | jq . >/dev/null
+else
+  curl -fsS "${BASE_URL}/api/miniweb/pin" >/dev/null
+fi
+
+echo "[smoke] GET /api/miniweb/scan-networks"
+if [[ "${HAS_JQ}" -eq 1 ]]; then
+  curl -fsS "${BASE_URL}/api/miniweb/scan-networks" | jq . >/dev/null
+else
+  curl -fsS "${BASE_URL}/api/miniweb/scan-networks" >/dev/null
+fi
+
+echo "[smoke] GET /config"
+CONFIG_HTML="$(curl -fsS "${BASE_URL}/config")"
+echo "${CONFIG_HTML}" | grep -qi "<html" || {
+  echo "[smoke][warn] /config no devolvió HTML" >&2
+  exit 1
+}
+
+echo "[smoke] OK"

--- a/systemd/bascula-miniweb.service
+++ b/systemd/bascula-miniweb.service
@@ -1,16 +1,17 @@
 [Unit]
 Description=Bascula Mini-Web Backend
-After=network.target NetworkManager.service
+After=network-online.target NetworkManager.service
+Wants=network-online.target
 
 [Service]
 Type=simple
 User=pi
 Group=pi
 WorkingDirectory=/opt/bascula/current
-Environment=PATH=/opt/bascula/current/.venv/bin
-# Permitir leer PIN vía API solo en modo AP; por defecto 0
-Environment=BASCULA_ALLOW_PIN_READ=0
-ExecStart=/opt/bascula/current/.venv/bin/python /opt/bascula/current/backend/miniweb.py
+Environment=PATH=/opt/bascula/current/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=BASCULA_CFG_DIR=/home/pi/.bascula
+Environment=BASCULA_ALLOW_PIN_READ=1
+ExecStart=/opt/bascula/current/.venv/bin/python -m uvicorn backend.miniweb:app --host 0.0.0.0 --port 8080
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
## Summary
- update the FastAPI miniweb backend to persist the PIN under ~/.bascula, expose the SPA from dist/, and implement NetworkManager-based Wi-Fi actions with clear error handling
- add PolicyKit rules and adjust the systemd service plus install script to provision uvicorn, copy the new rules, and enable the backend service automatically
- include a reusable smoke test script that validates the primary endpoints and static config page

## Testing
- python -m compileall backend/miniweb.py
- bash -n scripts/install-all.sh

------
https://chatgpt.com/codex/tasks/task_e_68df3efd52548326b16ff7a16ecec3a7