### PR TITLE
Harden mini-web WiFi and AP flows on Raspberry Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,16 @@ Read more here: [Setting up a custom domain](https://docs.lovable.dev/features/c
 
 ## Mini-Web (AP setup)
 
-Pruebas de aceptación rápidas (backend servido en `http://localhost:8080`):
+### 🚀 Migración rápida (Raspberry Pi con instalación existente)
+
+```bash
+cd /opt/bascula/current
+sudo ./scripts/migrate_2025_10.sh
+```
+
+El script aplica la nueva versión de `backend/miniweb.py`, instala la regla de PolicyKit, actualiza el servicio `bascula-miniweb.service` y crea el perfil `BasculaAP` de NetworkManager si falta. Después reinicia automáticamente el servicio.
+
+### ✅ Pruebas de aceptación rápidas (backend servido en `http://localhost:8080`)
 
 ```bash
 # Healthcheck
@@ -83,7 +92,7 @@ curl -s http://localhost:8080/health
 # SPA principal (debe devolver HTML, no una página en blanco)
 curl -s http://localhost:8080/ | head
 
-# Leer PIN (solo visible en modo AP, bandera o cabecera forzada)
+# Leer PIN (solo visible en modo AP o si BASCULA_ALLOW_PIN_READ=1)
 curl -s http://localhost:8080/api/miniweb/pin
 
 # Verificar PIN persistente
@@ -91,16 +100,20 @@ curl -s -X POST http://localhost:8080/api/miniweb/verify-pin \
   -H 'Content-Type: application/json' \
   -d '{"pin":"NNNN"}'
 
-# Escanear redes Wi-Fi (403 si falta permiso, 503 si no hay nmcli)
+# Escanear redes Wi-Fi (403 si falta PolicyKit, 503 si no existe /usr/bin/nmcli)
 curl -s http://localhost:8080/api/miniweb/scan-networks
 
-# Iniciar conexión Wi-Fi (ejemplo)
+# Iniciar conexión Wi-Fi (genera perfil .nmconnection con PSK)
 curl -s -X POST http://localhost:8080/api/miniweb/connect-wifi \
   -H 'Content-Type: application/json' \
   -d '{"ssid":"MiRed","password":"secreto"}'
 
 # Estado de red actual
 curl -s http://localhost:8080/api/network/status
+
+# Activar / desactivar modo AP gestionado por NetworkManager
+curl -s -X POST http://localhost:8080/api/network/enable-ap
+curl -s -X POST http://localhost:8080/api/network/disable-ap
 ```
 
 Expectativas clave:

--- a/etc/polkit-1/rules.d/10-bascula-nmcli.rules
+++ b/etc/polkit-1/rules.d/10-bascula-nmcli.rules
@@ -1,7 +1,9 @@
-// 10-bascula-nmcli.rules
 polkit.addRule(function(action, subject) {
-  if ((subject.isInGroup("pi") || subject.user === "pi")
-      && action.id.indexOf("org.freedesktop.NetworkManager.") === 0) {
-    return polkit.Result.YES;
+  if (subject.isInGroup("netdev") || subject.user == "pi") {
+    if (action.id == "org.freedesktop.NetworkManager.settings.modify.system" ||
+        action.id == "org.freedesktop.NetworkManager.network-control" ||
+        action.id == "org.freedesktop.NetworkManager.wifi.scan") {
+      return polkit.Result.YES;
+    }
   }
 });

--- a/scripts/migrate_2025_10.sh
+++ b/scripts/migrate_2025_10.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${EUID} -ne 0 ]]; then
+  echo "This script must be run as root (use sudo)." >&2
+  exit 1
+fi
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+TARGET_ROOT=/opt/bascula/current
+NM_DIR=/etc/NetworkManager/system-connections
+POLKIT_DIR=/etc/polkit-1/rules.d
+POLKIT_RULE=10-bascula-nm.rules
+SERVICE_NAME=bascula-miniweb.service
+AP_PROFILE=${NM_DIR}/BasculaAP.nmconnection
+
+mkdir -p "${TARGET_ROOT}/backend"
+install -m 644 "${REPO_ROOT}/backend/miniweb.py" "${TARGET_ROOT}/backend/miniweb.py"
+
+install -m 644 "${REPO_ROOT}/systemd/${SERVICE_NAME}" "/etc/systemd/system/${SERVICE_NAME}"
+
+mkdir -p "${POLKIT_DIR}"
+install -m 644 "${REPO_ROOT}/etc/polkit-1/rules.d/10-bascula-nmcli.rules" "${POLKIT_DIR}/${POLKIT_RULE}"
+
+if getent group netdev >/dev/null 2>&1; then
+  usermod -aG netdev pi || true
+fi
+
+if command -v uuidgen >/dev/null 2>&1; then
+  UUID_VALUE=$(uuidgen)
+else
+  UUID_VALUE=$(python3 -c 'import uuid; print(uuid.uuid4())')
+fi
+
+mkdir -p "${NM_DIR}"
+if [[ ! -f "${AP_PROFILE}" ]]; then
+  cat <<PROFILE > "${AP_PROFILE}"
+[connection]
+id=BasculaAP
+uuid=${UUID_VALUE}
+type=wifi
+interface-name=wlan0
+autoconnect=false
+
+[wifi]
+ssid=Bascula-AP
+mode=ap
+
+[wifi-security]
+key-mgmt=wpa-psk
+psk=bascula2025
+
+[ipv4]
+method=shared
+
+[ipv6]
+method=ignore
+PROFILE
+  chmod 600 "${AP_PROFILE}"
+fi
+
+systemctl daemon-reload
+if systemctl is-active --quiet polkit; then
+  systemctl restart polkit
+elif systemctl is-active --quiet polkitd; then
+  systemctl restart polkitd
+fi
+systemctl restart bascula-miniweb.service
+
+echo "Migration completed."

--- a/systemd/bascula-miniweb.service
+++ b/systemd/bascula-miniweb.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Bascula Mini-Web Backend
-After=network-online.target NetworkManager.service
-Wants=network-online.target
+After=network.target NetworkManager.service
 
 [Service]
 Type=simple
@@ -10,7 +9,7 @@ Group=pi
 WorkingDirectory=/opt/bascula/current
 Environment=PATH=/opt/bascula/current/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 Environment=BASCULA_CFG_DIR=/home/pi/.bascula
-Environment=BASCULA_ALLOW_PIN_READ=1
+# Environment=BASCULA_ALLOW_PIN_READ=1
 ExecStart=/opt/bascula/current/.venv/bin/python -m uvicorn backend.miniweb:app --host 0.0.0.0 --port 8080
 Restart=always
 RestartSec=5


### PR DESCRIPTION
## Summary
- serve the SPA assets safely while persisting and optionally exposing the mini-web PIN
- move WiFi scanning/connection and AP management to NetworkManager with nmcli hard paths and new migration script
- update the PolicyKit rule and systemd unit for the refreshed service setup

## Testing
- python -m compileall backend/miniweb.py

------
https://chatgpt.com/codex/tasks/task_e_68df424163e48326a57dc9cd744f7cd7