### PR TITLE
Handle zero current glucose in bolus calculator

### DIFF
--- a/src/components/BolusCalculator.tsx
+++ b/src/components/BolusCalculator.tsx
@@ -25,9 +25,10 @@ export const BolusCalculator = ({ totalCarbs, currentGlucose, onClose }: BolusCa
   const targetGlucose = settings.targetGlucose || 100;
 
   const carbsInsulin = totalCarbs / carbRatio;
-  const correctionInsulin = currentGlucose 
-    ? Math.max(0, (currentGlucose - targetGlucose) / correctionFactor)
-    : 0;
+  const correctionInsulin =
+    typeof currentGlucose === "number"
+      ? Math.max(0, (currentGlucose - targetGlucose) / correctionFactor)
+      : 0;
   const totalInsulin = carbsInsulin + correctionInsulin;
 
   const getTimingRecommendation = () => {
@@ -119,7 +120,7 @@ export const BolusCalculator = ({ totalCarbs, currentGlucose, onClose }: BolusCa
               <p className="text-3xl font-bold text-warning">{totalCarbs.toFixed(1)}g</p>
             </div>
             
-            {currentGlucose && (
+            {currentGlucose !== undefined && (
               <div className="rounded-lg bg-muted/30 p-4">
                 <p className="mb-1 text-sm text-muted-foreground">Glucosa Actual</p>
                 <p className="text-3xl font-bold text-primary">{currentGlucose} mg/dl</p>


### PR DESCRIPTION
## Summary
- guard the correction insulin calculation with an explicit number check so zero glucose values are included
- render the current glucose card whenever the value is defined, even when it is zero
- preserve logging and export behavior so zero glucose readings continue to propagate

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df7fc339a08326ba87451665e7231c