### PR TITLE
feat: allow updating API base URL without reload

### DIFF
--- a/src/pages/SettingsView.tsx
+++ b/src/pages/SettingsView.tsx
@@ -12,7 +12,7 @@ import { storage } from "@/services/storage";
 import { useToast } from "@/hooks/use-toast";
 import { useScaleWebSocket } from "@/hooks/useScaleWebSocket";
 import { cn } from "@/lib/utils";
-import { api } from "@/services/api";
+import { api, setApiBaseUrl } from "@/services/api";
 
 export const SettingsView = () => {
   const { toast } = useToast();
@@ -149,6 +149,7 @@ export const SettingsView = () => {
         storage.saveSettings({ hyperAlarm: parseFloat(tempValue) || 180 });
       } else if (field === 'apiUrl') {
         storage.saveSettings({ apiUrl: tempValue });
+        setApiBaseUrl(tempValue);
       } else if (field === 'wsUrl') {
         storage.saveSettings({ wsUrl: tempValue });
       }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,6 +3,10 @@ import { apiWrapper, ApiError } from './apiWrapper';
 import { storage } from './storage';
 import { logger } from './logger';
 
+export const setApiBaseUrl = (baseUrl: string) => {
+  apiWrapper.updateBaseUrl(baseUrl);
+};
+
 export interface WeightData {
   weight: number;
   stable: boolean;
@@ -65,7 +69,7 @@ class ApiService {
   constructor() {
     // Update API base URL from settings
     const settings = storage.getSettings();
-    apiWrapper.updateBaseUrl(settings.apiUrl);
+    setApiBaseUrl(settings.apiUrl);
   }
 
   // Scale endpoints


### PR DESCRIPTION
## Summary
- add a reusable helper in the API service to update the wrapper base URL
- apply the new helper when saving settings so API endpoint changes take effect immediately

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df804cd640832690082642fd21069e