### PR TITLE
Fix AI fallback cooldown handling

### DIFF
--- a/src/components/BarcodeScannerModal.tsx
+++ b/src/components/BarcodeScannerModal.tsx
@@ -391,6 +391,10 @@ export function BarcodeScannerModal({
 
   useEffect(() => cleanup, [cleanup]);
 
+  const resetCooldown = useCallback(() => {
+    setCooldownUntil(null);
+  }, []);
+
   const ensureCooldown = useCallback(() => {
     const now = Date.now();
     if (cooldownUntil && now < cooldownUntil) {
@@ -521,6 +525,7 @@ export function BarcodeScannerModal({
         });
         cleanup();
         setScanMode('barcode');
+        resetCooldown();
         startBarcodeScanning();
         return;
       }
@@ -565,7 +570,7 @@ export function BarcodeScannerModal({
     } finally {
       setLoading(false);
     }
-  }, [toast, cleanup, startBarcodeScanning]);
+  }, [toast, cleanup, startBarcodeScanning, resetCooldown]);
 
   const startAIScanning = useCallback(async () => {
     if (attemptCount >= MAX_ATTEMPTS) {
@@ -574,6 +579,7 @@ export function BarcodeScannerModal({
         description: 'Probando escaneo de código de barras',
       });
       setScanMode('barcode');
+      resetCooldown();
       startBarcodeScanning();
       return;
     }
@@ -607,11 +613,19 @@ export function BarcodeScannerModal({
         description: 'Probando escaneo de código de barras',
       });
       setScanMode('barcode');
+      resetCooldown();
       startBarcodeScanning();
     } finally {
       setLoading(false);
     }
-  }, [attemptCount, ensureCooldown, toast, startBarcodeScanning, captureAndAnalyze]);
+  }, [
+    attemptCount,
+    ensureCooldown,
+    toast,
+    startBarcodeScanning,
+    captureAndAnalyze,
+    resetCooldown,
+  ]);
 
   const handleStartWeighing = useCallback(() => {
     if (!productData.name || productData.carbsPer100g <= 0) {


### PR DESCRIPTION
## Summary
- add a resetCooldown helper so automatic barcode fallbacks can bypass the active cooldown
- invoke the helper whenever AI capture hands off to barcode scanning and keep hooks up to date with the new dependency

## Testing
- npm run lint *(fails: pre-existing lint errors about any types and react-refresh warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa524dfc88326af0e0f28c9d807dd