### PR TITLE
Add timestamp and photo support to scanner payloads

### DIFF
--- a/src/components/BarcodeScannerModal.tsx
+++ b/src/components/BarcodeScannerModal.tsx
@@ -677,6 +677,8 @@ export function BarcodeScannerModal({
       return;
     }
 
+    const confirmedAt = new Date();
+    const photo = productData.photo ?? capturedPhoto;
     const payload: FoodScannerConfirmedPayload = {
       name: productData.name,
       weight: pesoActual,
@@ -686,11 +688,13 @@ export function BarcodeScannerModal({
       glycemicIndex: productData.glycemicIndex,
       kcal: calculatedKcal > 0 ? calculatedKcal : undefined,
       confidence: productData.confidence || undefined,
+      timestamp: confirmedAt,
+      photo,
     };
 
     storage.addScannerRecord({
       ...payload,
-      photo: productData.photo,
+      timestamp: confirmedAt.toISOString(),
       carbsPer100g: productData.carbsPer100g,
       proteinsPer100g: productData.proteinsPer100g,
       fatsPer100g: productData.fatsPer100g,
@@ -704,7 +708,7 @@ export function BarcodeScannerModal({
     if (settings.nightscoutUrl && settings.nightscoutToken) {
       try {
         if (navigator.onLine) {
-          await api.exportBolus(calculatedCarbs, 0, new Date().toISOString());
+          await api.exportBolus(calculatedCarbs, 0, confirmedAt.toISOString());
           toast({
             title: 'Exportado a Nightscout',
             description: 'Revisa tu registro en Nightscout',
@@ -714,7 +718,7 @@ export function BarcodeScannerModal({
             type: 'exportBolus',
             carbs: calculatedCarbs,
             insulin: 0,
-            timestamp: new Date().toISOString(),
+            timestamp: confirmedAt.toISOString(),
           });
           toast({
             title: 'Sin conexión',
@@ -732,7 +736,7 @@ export function BarcodeScannerModal({
           type: 'exportBolus',
           carbs: calculatedCarbs,
           insulin: 0,
-          timestamp: new Date().toISOString(),
+          timestamp: confirmedAt.toISOString(),
         });
       }
     }
@@ -758,6 +762,7 @@ export function BarcodeScannerModal({
     onFoodConfirmed,
     onClose,
     toast,
+    capturedPhoto,
   ]);
 
   const parseVoiceTranscript = useCallback((transcript: string): Partial<ManualFormValues> => {

--- a/src/features/food-scanner/foodItem.ts
+++ b/src/features/food-scanner/foodItem.ts
@@ -21,6 +21,7 @@ export interface FoodItem {
   source: FoodSource;
   capturedAt: number;
   avgColor?: FoodColor;
+  photo?: string;
 }
 
 export interface FoodScannerConfirmedPayload {
@@ -33,6 +34,8 @@ export interface FoodScannerConfirmedPayload {
   kcal?: number;
   confidence?: number;
   avgColor?: FoodColor;
+  timestamp: Date;
+  photo?: string;
 }
 
 export type BarcodeScannerSnapshot = FoodScannerConfirmedPayload;
@@ -85,6 +88,7 @@ export const createScannerSnapshot = (
     kcal: calculateCalories(nutrition),
     confidence: analysis.confidence,
     avgColor: mapColor(analysis),
+    timestamp: new Date(),
   };
 };
 
@@ -102,8 +106,9 @@ export const toFoodItem = (
   kcal: snapshot.kcal,
   confidence: snapshot.confidence,
   source,
-  capturedAt: Date.now(),
+  capturedAt: snapshot.timestamp.getTime(),
   avgColor: snapshot.avgColor,
+  photo: snapshot.photo,
 });
 
 export const buildFoodItem = (

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -230,7 +230,11 @@ class StorageService {
   addScannerRecord(record: any): void {
     try {
       const history = this.getScannerHistory();
-      history.unshift({ ...record, timestamp: Date.now() });
+      const timestamp =
+        record.timestamp instanceof Date
+          ? record.timestamp.toISOString()
+          : record.timestamp ?? new Date().toISOString();
+      history.unshift({ ...record, timestamp });
       const trimmed = history.slice(0, MAX_HISTORY_ITEMS);
       this.saveScannerHistory(trimmed);
     } catch (error) {
@@ -254,7 +258,11 @@ class StorageService {
   enqueueScannerAction(action: any): void {
     try {
       const queue = this.getScannerQueue();
-      queue.push({ ...action, queuedAt: Date.now() });
+      const timestamp =
+        action.timestamp instanceof Date
+          ? action.timestamp.toISOString()
+          : action.timestamp;
+      queue.push({ ...action, timestamp, queuedAt: Date.now() });
       localStorage.setItem('scanner_history_queue', JSON.stringify(queue));
     } catch (error) {
       console.error('Error enqueuing scanner action:', error);

--- a/tests/food-scanner-contract.test.ts
+++ b/tests/food-scanner-contract.test.ts
@@ -45,6 +45,7 @@ describe("food scanner contract", () => {
       kcal: 53.21,
       confidence: 0.82,
       avgColor: { r: 120, g: 85, b: 60 },
+      timestamp: new Date("2024-01-01T00:00:00.000Z"),
     });
   });
 
@@ -58,6 +59,8 @@ describe("food scanner contract", () => {
       glycemicIndex: 30,
       confidence: 0.91,
       avgColor: { r: 200, g: 210, b: 220 },
+      timestamp: new Date("2024-01-01T00:00:00.000Z"),
+      photo: "data:image/png;base64,photo",
     };
 
     const item = toFoodItem(snapshot, "barcode");
@@ -74,6 +77,7 @@ describe("food scanner contract", () => {
       source: "barcode",
       capturedAt: 1704067200000,
       avgColor: { r: 200, g: 210, b: 220 },
+      photo: "data:image/png;base64,photo",
     });
   });
 


### PR DESCRIPTION
## Summary
- include timestamp and optional photo on `FoodScannerConfirmedPayload` and propagate through `FoodItem`
- attach confirmation timestamps/photos in `BarcodeScannerModal` and ensure storage/queue persistence keeps them
- refresh tests to cover the extended payload contract and adjusted carb expectations

## Testing
- npx vitest run tests/BarcodeScannerModal.test.tsx
- npx vitest run tests/food-scanner-contract.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dfa77aa7588326a2a483b3d4be62a4