### PR TITLE
Refine Wi-Fi provisioning workflow for Raspberry Pi install

### DIFF
--- a/MINI_WEB_AND_AP.md
+++ b/MINI_WEB_AND_AP.md
@@ -46,8 +46,8 @@ Sistema completo de fallback WiFi con mini-web de configuración que se activa a
 - **Endpoints**:
   - `POST /api/miniweb/verify-pin` - Verificar PIN
   - `GET /api/miniweb/scan-networks` - Escanear redes WiFi
-  - `POST /api/miniweb/connect-wifi` - Conectar a red
-  - `GET /api/network/status` - Estado de red actual
+  - `POST /api/miniweb/connect` - Conectar a red (alias legacy `/api/miniweb/connect-wifi`)
+  - `GET /api/miniweb/status` - Estado de red actual (alias legacy `/api/network/status`)
   - `POST /api/network/enable-ap` - Activar modo AP
   - `POST /api/network/disable-ap` - Desactivar modo AP
 
@@ -331,14 +331,14 @@ curl http://192.168.4.1:8080/api/miniweb/scan-networks
 
 ### Conectar WiFi
 ```bash
-curl -X POST http://192.168.4.1:8080/api/miniweb/connect-wifi \
+curl -X POST http://192.168.4.1:8080/api/miniweb/connect \
   -H "Content-Type: application/json" \
   -d '{"ssid":"MiRed","password":"mipassword"}'
 ```
 
 ### Estado de Red
 ```bash
-curl http://192.168.4.1:8080/api/network/status
+curl http://192.168.4.1:8080/api/miniweb/status
 ```
 
 ---

--- a/packaging/polkit/49-nmcli.rules
+++ b/packaging/polkit/49-nmcli.rules
@@ -9,5 +9,11 @@ polkit.addRule(function(action, subject) {
     if (action.id == "org.freedesktop.NetworkManager.wifi.scan") {
       return polkit.Result.YES;
     }
+    if (action.id == "org.freedesktop.NetworkManager.wifi.share.protected") {
+      return polkit.Result.YES;
+    }
+    if (action.id == "org.freedesktop.NetworkManager.wifi.share.open") {
+      return polkit.Result.YES;
+    }
   }
 });

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Script de instalación completa para Báscula Inteligente
+# Script de instalación completa para Báscula Digital Pro (bascula-cam)
 # Raspberry Pi 5 + Bookworm Lite 64-bit
 # - Instala estructura OTA con versionado
 # - Configura HDMI (1024x600), KMS, I2S audio, UART, Camera Module 3
@@ -93,7 +93,7 @@ BOOTDIR="/boot/firmware"
 CONF="${BOOTDIR}/config.txt"
 
 log "============================================"
-log "  Instalación Completa - Báscula Inteligente"
+log "  Instalación Completa - Báscula Digital Pro"
 log "============================================"
 log "Target user      : $TARGET_USER ($TARGET_GROUP)"
 log "Target home      : $TARGET_HOME"
@@ -346,6 +346,12 @@ polkit.addRule(function(action, subject) {
       return polkit.Result.YES;
     }
     if (action.id == "org.freedesktop.NetworkManager.wifi.scan") {
+      return polkit.Result.YES;
+    }
+    if (action.id == "org.freedesktop.NetworkManager.wifi.share.protected") {
+      return polkit.Result.YES;
+    }
+    if (action.id == "org.freedesktop.NetworkManager.wifi.share.open") {
       return polkit.Result.YES;
     }
   }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -58,7 +58,7 @@ const Index = () => {
 
     const verifyBackend = async () => {
       try {
-        const response = await fetch('/api/network/status', { cache: 'no-store' });
+        const response = await fetch('/api/miniweb/status', { cache: 'no-store' });
         if (!response.ok) {
           return;
         }


### PR DESCRIPTION
## Summary
- overhaul the mini-web backend to manage Wi-Fi profiles through nmcli, expose the new /api/miniweb/status endpoint, and return richer scan results
- relax PolicyKit rules and installation scripts so the pi user can manage Wi-Fi sharing, update the net-fallback script to skip AP mode when Ethernet is active, and point the kiosk to http://localhost:8080
- refresh the mini-web UI and documentation to consume the new API responses, surface security/in-use metadata, and document the clean installation workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfd28f45a88326b97904f86abe043b