### PR TITLE
Ensure NetworkManager permissions for pi user

### DIFF
--- a/etc/polkit-1/rules.d/10-bascula-nmcli.rules
+++ b/etc/polkit-1/rules.d/10-bascula-nmcli.rules
@@ -1,8 +1,10 @@
 polkit.addRule(function(action, subject) {
   if (subject.isInGroup("netdev") || subject.user == "pi") {
     if (action.id == "org.freedesktop.NetworkManager.settings.modify.system" ||
+        action.id == "org.freedesktop.NetworkManager.settings.modify.own" ||
         action.id == "org.freedesktop.NetworkManager.network-control" ||
-        action.id == "org.freedesktop.NetworkManager.wifi.scan") {
+        action.id == "org.freedesktop.NetworkManager.wifi.scan" ||
+        action.id == "org.freedesktop.NetworkManager.enable-disable-wifi") {
       return polkit.Result.YES;
     }
   }

--- a/packaging/polkit/49-nmcli.rules
+++ b/packaging/polkit/49-nmcli.rules
@@ -3,10 +3,16 @@ polkit.addRule(function(action, subject) {
     if (action.id == "org.freedesktop.NetworkManager.settings.modify.system") {
       return polkit.Result.YES;
     }
+    if (action.id == "org.freedesktop.NetworkManager.settings.modify.own") {
+      return polkit.Result.YES;
+    }
     if (action.id == "org.freedesktop.NetworkManager.network-control") {
       return polkit.Result.YES;
     }
     if (action.id == "org.freedesktop.NetworkManager.wifi.scan") {
+      return polkit.Result.YES;
+    }
+    if (action.id == "org.freedesktop.NetworkManager.enable-disable-wifi") {
       return polkit.Result.YES;
     }
     if (action.id == "org.freedesktop.NetworkManager.wifi.share.protected") {


### PR DESCRIPTION
## Summary
- extend the NetworkManager polkit rules so pi/netdev can modify own settings and toggle Wi-Fi
- update the installer to add pi to netdev, deploy the rule with correct permissions, restart services, and perform nmcli checks

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dfe150aee88326b5983050b0e48ce9