### PR TITLE
Fix pigpio group detection in install script

### DIFF
--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -213,12 +213,12 @@ fi
 systemctl_safe enable pigpiod
 systemctl_safe start pigpiod
 
-if getent group pigpi >/dev/null 2>&1; then
-  if ! id -nG "${TARGET_USER}" | tr ' ' '\n' | grep -q '^pigpi$'; then
-    if usermod -aG pigpi "${TARGET_USER}"; then
-      log "Usuario ${TARGET_USER} añadido al grupo pigpi"
+if getent group pigpio >/dev/null 2>&1; then
+  if ! id -nG "${TARGET_USER}" | tr ' ' '\n' | grep -q '^pigpio$'; then
+    if usermod -aG pigpio "${TARGET_USER}"; then
+      log "Usuario ${TARGET_USER} añadido al grupo pigpio"
     else
-      warn "No se pudo añadir ${TARGET_USER} al grupo pigpi"
+      warn "No se pudo añadir ${TARGET_USER} al grupo pigpio"
     fi
   fi
 fi


### PR DESCRIPTION
## Summary
- correct the pigpio group name used when checking and adding the target user
- ensure the install script successfully adds the user to the pigpio group created by the package

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dfe79d0bc88326b4fb3ea53ef23136