### PR TITLE
Fix install script for Bookworm kiosk environment

### DIFF
--- a/.xinitrc
+++ b/.xinitrc
@@ -16,7 +16,8 @@ openbox &
 sleep 2
 
 # Lanzar Chromium en modo kiosk
-chromium \
+CHROME_BIN="$(command -v chromium 2>/dev/null || command -v chromium-browser 2>/dev/null || command -v ${CHROME_PKG:-chromium} 2>/dev/null || echo chromium)"
+exec "$CHROME_BIN" \
   --kiosk \
   --noerrdialogs \
   --disable-infobars \

--- a/backend/miniweb.py
+++ b/backend/miniweb.py
@@ -1,5 +1,6 @@
 # backend/miniweb.py
 # (Codex: escribir archivo COMPLETO, sin "...", listo para ejecutar)
+from __future__ import annotations
 import os
 import json
 import logging

--- a/packaging/polkit/49-nmcli.rules
+++ b/packaging/polkit/49-nmcli.rules
@@ -15,11 +15,5 @@ polkit.addRule(function(action, subject) {
     if (action.id == "org.freedesktop.NetworkManager.enable-disable-wifi") {
       return polkit.Result.YES;
     }
-    if (action.id == "org.freedesktop.NetworkManager.wifi.share.protected") {
-      return polkit.Result.YES;
-    }
-    if (action.id == "org.freedesktop.NetworkManager.wifi.share.open") {
-      return polkit.Result.YES;
-    }
   }
 });

--- a/systemd/bascula-ui.service
+++ b/systemd/bascula-ui.service
@@ -18,7 +18,7 @@ PermissionsStartOnly=yes
 ExecStartPre=/usr/bin/install -d -m 0755 -o pi -g pi /var/log/bascula
 ExecStartPre=/usr/bin/install -o pi -g pi -m 0644 /dev/null /var/log/bascula/app.log
 ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /home/pi/.local/share/xorg
-ExecStart=/usr/bin/startx -- :0 vt1
+ExecStart=/bin/bash -lc 'STARTX_BIN="$(command -v startx || command -v xinit)"; if [ -z "$STARTX_BIN" ]; then echo "startx/xinit no disponible" >&2; exit 1; fi; if [ "$(basename "$STARTX_BIN")" = "startx" ]; then exec "$STARTX_BIN" -- :0 vt1; else exec "$STARTX_BIN" "$HOME/.xinitrc" -- :0 vt1; fi'
 Restart=on-failure
 RestartSec=2
 StandardOutput=journal


### PR DESCRIPTION
## Summary
- harden the installer by checking apt candidates, selecting the available Chromium package, ensuring python3-pigpio, configuring polkit rules, and validating nmcli without sudo
- update the kiosk startup files to detect the correct Chromium binary and X launcher at runtime
- prevent a CalibrationPayload NameError in miniweb by enabling postponed annotations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfe90014f483269c7b30b4c170091a