### PR TITLE
Handle scale stability in HTTP polling

### DIFF
--- a/src/hooks/useScaleWebSocket.ts
+++ b/src/hooks/useScaleWebSocket.ts
@@ -8,8 +8,22 @@ const INITIAL_RECONNECT_DELAY = 1000; // 1 second
 const MAX_RECONNECT_DELAY = 30000; // 30 seconds
 const READ_POLL_INTERVAL = 300; // ms
 const STATUS_POLL_INTERVAL = 2000; // ms
+const SAMPLE_WINDOW = 12;
+const EPS_GRAMS = 0.5;
+const MIN_STABLE_MS = 1500;
 
-interface UseScaleWebSocketReturn {
+type Sample = { value: number; timestamp: number };
+
+type ReadResp = {
+  ok: boolean;
+  grams?: number;
+  stable?: boolean;
+  ts?: string;
+  weight?: number;
+  reason?: string;
+};
+
+export interface UseScaleWebSocketReturn {
   weight: number;
   isStable: boolean;
   unit: "g" | "ml";
@@ -36,6 +50,7 @@ export const useScaleWebSocket = (): UseScaleWebSocketReturn => {
   const readInFlightRef = useRef(false);
   const statusInFlightRef = useRef(false);
   const isPollingRef = useRef(false);
+  const stabilitySamplesRef = useRef<Sample[]>([]);
 
   const settings = storage.getSettings();
   const defaultOrigin = typeof window !== "undefined" ? window.location.origin : "";
@@ -111,23 +126,64 @@ export const useScaleWebSocket = (): UseScaleWebSocketReturn => {
           return;
         }
 
-        const data = await response.json();
+        const data: ReadResp = await response.json();
 
         if (data?.ok === true) {
-          const gramsValue = typeof data.grams === "number"
-            ? data.grams
-            : typeof data.weight === "number"
-              ? data.weight
-              : 0;
-          const stableValue = typeof data.stable === "boolean"
-            ? data.stable
-            : false;
+          const gramsValue =
+            typeof data.grams === "number"
+              ? data.grams
+              : typeof data.weight === "number"
+                ? data.weight
+                : 0;
+
+          const now = Date.now();
+          stabilitySamplesRef.current.push({ value: gramsValue, timestamp: now });
+          if (stabilitySamplesRef.current.length > SAMPLE_WINDOW) {
+            stabilitySamplesRef.current.splice(
+              0,
+              stabilitySamplesRef.current.length - SAMPLE_WINDOW,
+            );
+          }
 
           setWeight(gramsValue);
-          setIsStable(stableValue);
           setUnit("g");
           setIsConnected(true);
           setError(null);
+
+          if (typeof data.stable === "boolean") {
+            setIsStable(data.stable);
+          } else {
+            setIsStable(prevStable => {
+              const samples = stabilitySamplesRef.current;
+              if (samples.length < SAMPLE_WINDOW) {
+                return prevStable;
+              }
+
+              const elapsed = now - samples[0].timestamp;
+              if (elapsed < MIN_STABLE_MS) {
+                return prevStable;
+              }
+
+              let min = Number.POSITIVE_INFINITY;
+              let max = Number.NEGATIVE_INFINITY;
+
+              for (const sample of samples) {
+                if (sample.value < min) {
+                  min = sample.value;
+                }
+                if (sample.value > max) {
+                  max = sample.value;
+                }
+              }
+
+              const range = Math.abs(max - min);
+              if (range < EPS_GRAMS) {
+                return true;
+              }
+
+              return false;
+            });
+          }
         } else {
           setIsConnected(false);
           if (typeof data?.reason === "string") {


### PR DESCRIPTION
## Summary
- add client-side stability derivation when HTTP polling lacks the stable flag
- preserve previous stability through polling errors and maintain recent sample history
- keep demo mode gated on VITE_DEMO and clean up polling lifecycle helpers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e000ed74cc8326b340332e806554cb