### PR TITLE
Use deterministic cache version in service worker

### DIFF
--- a/public/service-worker.tmpl.js
+++ b/public/service-worker.tmpl.js
@@ -1,4 +1,5 @@
-const CACHE_VERSION = `v${Date.now()}`;
+// Se sustituye en build por install-all.sh
+const CACHE_VERSION = "__CACHE_VERSION__";
 const STATIC_CACHE = `bascula-static-${CACHE_VERSION}`;
 const PRECACHE_ASSETS = [
   '/manifest.json',
@@ -25,11 +26,8 @@ self.addEventListener('activate', (event) => {
     (async () => {
       const keys = await caches.keys();
       await Promise.all(
-        keys.map((key) => {
-          if (key !== STATIC_CACHE) {
-            return caches.delete(key);
-          }
-          return Promise.resolve();
+        keys.map((k) => {
+          if (k !== STATIC_CACHE) return caches.delete(k);
         })
       );
       await self.clients.claim();

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -1145,6 +1145,12 @@ if [[ -f "package.json" ]]; then
     cp -f .env.device .env
   fi
   npm install || warn "npm install falló, continuar con backend"
+  PKG_VERSION="$(jq -r '.version' package.json 2>/dev/null || echo 0.0.0)"
+  GIT_SHA="$(git rev-parse --short HEAD || echo nogit)"
+  CACHE_VER="v${PKG_VERSION}-${GIT_SHA}"
+  if [ -f public/service-worker.tmpl.js ]; then
+    sed "s#__CACHE_VERSION__#${CACHE_VER}#g" public/service-worker.tmpl.js > public/service-worker.js
+  fi
   npm run build || warn "npm build falló"
   log "✓ Frontend compilado"
 fi


### PR DESCRIPTION
## Summary
- convert the service worker into a template that receives a deterministic cache version during build
- inject a cache version derived from package.json and the current git SHA before running the frontend build

## Testing
- not run (not requested)

Instrucciones para Codex (pégalos tal cual en el PR o comentario):

@codex Por favor, aplica estos cambios en el repo DanielGTdiabetes/bascula-cam:

1) Convertir el service worker a plantilla con versión estable

Renombra public/service-worker.js → public/service-worker.tmpl.js.

En esa nueva plantilla, reemplaza la línea de versión:

Antes:

const CACHE_VERSION = `v${Date.now()}`;


Después:

// Se sustituye en build por install-all.sh
const CACHE_VERSION = "__CACHE_VERSION__";
const STATIC_CACHE = `bascula-static-${CACHE_VERSION}`;


Mantén el resto del código igual (skipWaiting, purge de caches antiguos, network-first, etc.).
Importante: no introduzcas cambios de semántica; solo el origen de CACHE_VERSION.

2) Generar el service worker real en build (install-all.sh)

En scripts/install-all.sh, antes del build del frontend (en el bloque donde se hace npm run build o similar):

Lee version de package.json y el commit corto:

PKG_VERSION="$(jq -r '.version' package.json)"
GIT_SHA="$(git rev-parse --short HEAD || echo nogit)"
CACHE_VER="v${PKG_VERSION}-${GIT_SHA}"


Genera public/service-worker.js desde la plantilla:

if [ -f public/service-worker.tmpl.js ]; then
  sed "s#__CACHE_VERSION__#${CACHE_VER}#g" public/service-worker.tmpl.js > public/service-worker.js
fi


Continúa con el build como ya hacéis (asegúrate de que el install-all.sh copia .env.device antes de build, como ya está implementado).

Notas:

El nombre del fichero servido seguirá siendo public/service-worker.js (la app no necesita cambiar el path de registro).

La versión de caché cambia solo cuando cambia package.json o el commit, no en cada reinicio del SW.

Esto soluciona el problema reportado por Codex: “Use deterministic cache version in service worker”.

3) Seguridad y limpieza (opcional pero recomendado)

En el service worker, confirma que en el evento activate se borran caches antiguos que no coincidan con STATIC_CACHE:

self.addEventListener('activate', (event) => {
  event.waitUntil((async () => {
    const keys = await caches.keys();
    await Promise.all(
      keys.map((k) => {
        if (k !== STATIC_CACHE) return caches.delete(k);
      })
    );
    await self.clients.claim();
  })());
});


No cambies la estrategia network-first que ya ajustasteis.


------
https://chatgpt.com/codex/tasks/task_e_68e00e31c1388326b9afdd194f054c06