### PR TITLE
Ensure service worker generated during standalone builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "prebuild": "node scripts/generate-service-worker.mjs",
     "dev": "vite",
     "build": "vite build",
     "build:dev": "vite build --mode development",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,6 +14,10 @@ else
   npm install --no-audit --no-fund
 fi
 
+if command -v node >/dev/null 2>&1; then
+  node scripts/generate-service-worker.mjs
+fi
+
 npm run build
 
 mkdir -p "${DIST_DIR}/config"

--- a/scripts/generate-service-worker.mjs
+++ b/scripts/generate-service-worker.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises';
+import { access } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const publicDir = path.join(rootDir, 'public');
+const templatePath = path.join(publicDir, 'service-worker.tmpl.js');
+const outputPath = path.join(publicDir, 'service-worker.js');
+
+async function templateExists() {
+  try {
+    await access(templatePath, constants.F_OK);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+async function readPackageVersion() {
+  try {
+    const pkgRaw = await readFile(path.join(rootDir, 'package.json'), 'utf8');
+    const pkg = JSON.parse(pkgRaw);
+    if (typeof pkg.version === 'string' && pkg.version.trim() !== '') {
+      return pkg.version.trim();
+    }
+  } catch (error) {
+    // ignore
+  }
+  return '0.0.0';
+}
+
+function readGitSha() {
+  try {
+    const sha = execSync('git rev-parse --short HEAD', {
+      cwd: rootDir,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+    if (sha) {
+      return sha;
+    }
+  } catch (error) {
+    // ignore
+  }
+  return 'nogit';
+}
+
+async function generate() {
+  if (!(await templateExists())) {
+    return;
+  }
+
+  const pkgVersion = await readPackageVersion();
+  const gitSha = readGitSha();
+  const cacheVersion = `v${pkgVersion}-${gitSha}`;
+
+  const template = await readFile(templatePath, 'utf8');
+  const generated = template.replace(/__CACHE_VERSION__/g, cacheVersion);
+  await writeFile(outputPath, generated, 'utf8');
+
+  console.log(`Generated service worker (${path.relative(rootDir, outputPath)}) with cache version ${cacheVersion}`);
+}
+
+generate().catch((error) => {
+  console.error('Failed to generate service worker', error);
+  process.exitCode = 1;
+});

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -1145,11 +1145,12 @@ if [[ -f "package.json" ]]; then
     cp -f .env.device .env
   fi
   npm install || warn "npm install falló, continuar con backend"
-  PKG_VERSION="$(jq -r '.version' package.json 2>/dev/null || echo 0.0.0)"
-  GIT_SHA="$(git rev-parse --short HEAD || echo nogit)"
-  CACHE_VER="v${PKG_VERSION}-${GIT_SHA}"
-  if [ -f public/service-worker.tmpl.js ]; then
-    sed "s#__CACHE_VERSION__#${CACHE_VER}#g" public/service-worker.tmpl.js > public/service-worker.js
+  if command -v node >/dev/null 2>&1; then
+    if ! node scripts/generate-service-worker.mjs; then
+      warn "No se pudo generar service worker"
+    fi
+  else
+    warn "Node.js no disponible para generar service worker"
   fi
   npm run build || warn "npm build falló"
   log "✓ Frontend compilado"


### PR DESCRIPTION
## Summary
- add a Node-based generator that expands the service worker template with the deterministic cache version
- invoke the generator from npm prebuild, scripts/build.sh, and install-all.sh so every build path emits public/service-worker.js

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0111d01c4832698fb1d9a2db7c929