### PR TITLE
Ajusta cadencia del WebSocket de báscula

### DIFF
--- a/backend/miniweb.py
+++ b/backend/miniweb.py
@@ -1084,12 +1084,24 @@ async def ws_scale(websocket: WebSocket):
             else:
                 await websocket.send_json({"ok": False, **data})
 
+            # Ritmo de emisión (fluido)
             cfg = _load_config()
-            try:
-                sr = float(cfg.get("scale", {}).get("sample_rate_hz", 20.0))
-            except Exception:
-                sr = 20.0
-            interval = max(0.05, min(0.2, 1.0 / sr if sr > 0 else 0.1))
+            scale_cfg = cfg.get("scale", {}) if isinstance(cfg.get("scale"), dict) else {}
+
+            def _as_float(v, default):
+                try:
+                    return float(v)
+                except Exception:
+                    return default
+
+            # Permitir override específico para WS
+            ws_rate_hz = _as_float(scale_cfg.get("ws_rate_hz"), None)
+            sample_rate_hz = _as_float(scale_cfg.get("sample_rate_hz"), 20.0)
+            emit_hz = ws_rate_hz if (ws_rate_hz and ws_rate_hz > 0) else sample_rate_hz
+
+            # Intervalo entre 0.03s (≈33 Hz) y 0.2s (5 Hz)
+            interval = 1.0 / emit_hz if emit_hz > 0 else 0.1
+            interval = max(0.03, min(0.2, interval))
             await asyncio.sleep(interval)
 
     except WebSocketDisconnect:


### PR DESCRIPTION
## Summary
- permite que la cadencia del WebSocket se derive de scale.ws_rate_hz cuando esté configurado
- ajusta el intervalo de emisión para suavizar el streaming entre 0.03s y 0.2s

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e015bc37c88326acdd5a3cd62cba38