### PR TITLE
Add polkit rule for NetworkManager control by pi user

### DIFF
--- a/system/os/10-bascula-nm.rules
+++ b/system/os/10-bascula-nm.rules
@@ -1,0 +1,14 @@
+// Permitir a 'pi' gestionar NetworkManager sin prompt en el dispositivo
+// Colocar en: /etc/polkit-1/rules.d/10-bascula-nm.rules
+polkit.addRule(function(action, subject) {
+  if (subject.user === "pi") {
+    // Permisos amplios de NM en equipo dedicado (kiosco)
+    if (action.id.startsWith("org.freedesktop.NetworkManager.")) {
+      return polkit.Result.YES;
+    }
+    // Permitir modificar conexiones del sistema
+    if (action.id.startsWith("org.freedesktop.NetworkManager.settings.")) {
+      return polkit.Result.YES;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add a dedicated polkit rule so the `pi` user can manage NetworkManager without authentication prompts
- update the installation script to deploy the new rule and reload polkit/NetworkManager when systemd is available

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e09edda88c8326a2ab160d79a8fbfd