### PR TITLE
Handle secured flag when connecting miniweb wifi

### DIFF
--- a/backend/dist/service-worker.js
+++ b/backend/dist/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v2025.03.02';
+const CACHE_VERSION = 'v2025.03.02a';
 const STATIC_CACHE = `bascula-static-${CACHE_VERSION}`;
 const DYNAMIC_CACHE = `bascula-dynamic-${CACHE_VERSION}`;
 const RECOVERY_CACHE = `bascula-recovery-${CACHE_VERSION}`;


### PR DESCRIPTION
## Summary
- send the secured flag alongside the SSID and password when connecting to Wi-Fi from the miniweb UI and keep password validation aligned with network security
- improve connection error reporting and log output without exposing the password length
- bump the service worker cache version to invalidate old cached bundles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0b4690e2083268641204acf2d673d