### PR TITLE
Fix MiniWeb Wi-Fi connect payload

### DIFF
--- a/src/pages/MiniWebConfig.tsx
+++ b/src/pages/MiniWebConfig.tsx
@@ -199,10 +199,16 @@ export const MiniWebConfig = () => {
       try {
         console.log('[miniweb] connect', { ssid, secured, pwdLen: wifiPassword.length });
         setUi((prev) => ({ ...prev, connecting: true, error: '' }));
+        const payload = {
+          ssid,
+          password: wifiPassword,
+          secured,
+        };
+
         const res = await fetch('/api/miniweb/connect-wifi', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ssid, password: wifiPassword, secured }),
+          body: JSON.stringify(payload),
         });
         if (!res.ok) {
           const errorBody = (await res.json().catch(() => null)) as
@@ -252,7 +258,10 @@ export const MiniWebConfig = () => {
       }
     };
 
-    const selectedSecured = Boolean(selectedNetwork?.secured ?? requiresPassword);
+    const selectedSecured =
+      typeof selectedNetwork?.secured === 'boolean'
+        ? selectedNetwork.secured
+        : Boolean(selectedNetwork?.sec && selectedNetwork.sec.toUpperCase() !== 'NONE');
 
     void connectWifi(
       selectedSSID,


### PR DESCRIPTION
## Summary
- ensure the MiniWeb Wi-Fi connect request always includes the `secured` flag
- derive the `secured` value from the selected network's security metadata to handle open and protected networks

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e0b78f37488326801db14ab0e83e1b