### PR TITLE
Replace dnsmasq with dnsmasq-base for NetworkManager AP mode

### DIFF
--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -224,13 +224,21 @@ if [[ "${NET_OK}" -eq 1 ]]; then
         libjpeg-dev zlib1g-dev libpng-dev
         alsa-utils sox ffmpeg
         libzbar0 gpiod python3-rpi.gpio
-        network-manager dnsmasq dnsutils jq sqlite3 tesseract-ocr tesseract-ocr-spa espeak-ng
+        network-manager dnsmasq-base dnsutils jq sqlite3 tesseract-ocr tesseract-ocr-spa espeak-ng
         uuid-runtime
     )
     if apt_install "${BASE_PACKAGES[@]}"; then
         log "✓ Dependencias base instaladas"
     else
         warn "No se pudieron instalar todas las dependencias base"
+    fi
+
+    # Ensure global dnsmasq service is not running (NM will spawn its own instance)
+    if [[ "${HAS_SYSTEMD}" -eq 1 ]] && systemctl list-unit-files | grep -q '^dnsmasq\.service'; then
+        log "Deshabilitando servicio global de dnsmasq para evitar conflictos con NetworkManager"
+        systemctl stop dnsmasq 2>/dev/null || true
+        systemctl disable dnsmasq 2>/dev/null || true
+        systemctl mask dnsmasq 2>/dev/null || true
     fi
 
     ensure_pkg xorg


### PR DESCRIPTION
## Summary
- switch the installer to install dnsmasq-base instead of the full dnsmasq daemon to avoid port 53 conflicts
- add a hardening step that stops, disables, and masks any existing system-wide dnsmasq service so NetworkManager can manage its own instance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0d88e2e4083268778f9eb51acdaa9