### PR TITLE
Harden Bascula AP configuration

### DIFF
--- a/system/os/bascula-ap-ensure.service
+++ b/system/os/bascula-ap-ensure.service
@@ -1,16 +1,12 @@
 [Unit]
-Description=Ensure BasculaAP is active when no other connectivity exists
+Description=Ensure Bascula AP when no other connectivity
 After=NetworkManager.service
-Wants=NetworkManager.service
-ConditionPathExists=/usr/local/sbin/bascula-ap-ensure.sh
+Wants=network-online.target
 
 [Service]
 Type=oneshot
 ExecStart=/usr/local/sbin/bascula-ap-ensure.sh
 RemainAfterExit=yes
-TimeoutSec=20
-StandardOutput=journal
-StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/system/os/bascula-ap-ensure.sh
+++ b/system/os/bascula-ap-ensure.sh
@@ -4,49 +4,93 @@
 #
 set -euo pipefail
 
-LOG() { logger -t bascula-ap-ensure "$@"; printf "[ap-ensure] %s\n" "$@"; }
+LOG_TAG="bascula-ap-ensure"
+LOG_FILE="/var/log/bascula/ap-ensure.log"
+TMP_OUTPUT="$(mktemp -t bascula-ap-ensure.XXXXXX 2>/dev/null || echo "/tmp/bascula-ap-ensure.$$")"
+trap 'rm -f "${TMP_OUTPUT}" 2>/dev/null || true' EXIT
+
+mkdir -p "$(dirname "${LOG_FILE}")" >/dev/null 2>&1 || true
+
+LOG() {
+  local msg="$*"
+  logger -t "${LOG_TAG}" -- "${msg}" 2>/dev/null || true
+  printf "[ap-ensure] %s\n" "${msg}"
+  printf '%s %s\n' "$(date --iso-8601=seconds 2>/dev/null || date)" "${msg}" >>"${LOG_FILE}" 2>/dev/null || true
+}
+
+NMCLI_DIAG() {
+  LOG "Diagnóstico NetworkManager (${AP_IFACE}/${AP_NAME})"
+  if command -v nmcli >/dev/null 2>&1; then
+    while IFS= read -r line; do LOG "[diag] ${line}"; done < <(nmcli -f GENERAL,IP4,CONNECTION device show "${AP_IFACE}" 2>/dev/null || true)
+    while IFS= read -r line; do LOG "[diag] ${line}"; done < <(nmcli connection show "${AP_NAME}" 2>/dev/null || true)
+  fi
+}
 
 AP_NAME="${AP_NAME:-BasculaAP}"
 AP_IFACE="${AP_IFACE:-wlan0}"
 
-# Check if we have active ethernet with IP
-HAS_ETH=0
-if ip -4 addr show | grep -E '^[0-9]+: eth' | grep -q 'inet '; then
-  HAS_ETH=1
-  LOG "Ethernet active with IP, skipping AP"
-fi
+HAS_CONNECTIVITY=0
 
-# Check if we have active Wi-Fi client with IP (not AP mode)
-HAS_WIFI_CLIENT=0
 if command -v nmcli >/dev/null 2>&1; then
-  ACTIVE_CONN=$(nmcli -t -g NAME,TYPE,DEVICE connection show --active 2>/dev/null || true)
-  while IFS=: read -r NAME TYPE DEVICE; do
-    if [[ "${TYPE}" == "802-11-wireless" ]] && [[ "${DEVICE}" == "${AP_IFACE}" ]]; then
-      MODE=$(nmcli -t -g 802-11-wireless.mode connection show "${NAME}" 2>/dev/null || true)
-      if [[ "${MODE}" != "ap" ]]; then
-        # Check if it has IP
-        if ip -4 addr show dev "${AP_IFACE}" | grep -q 'inet '; then
-          HAS_WIFI_CLIENT=1
-          LOG "Wi-Fi client active with IP: ${NAME}, skipping AP"
-          break
-        fi
+  while IFS=: read -r DEVICE TYPE STATE; do
+    [[ -z "${DEVICE}" ]] && continue
+    [[ "${STATE}" != connected* ]] && continue
+
+    if [[ "${TYPE}" == "wifi" ]]; then
+      CONN_LINE=$(nmcli -t -f GENERAL.CONNECTION device show "${DEVICE}" 2>/dev/null || true)
+      CONN_NAME="${CONN_LINE#*:}"
+      [[ -z "${CONN_NAME}" ]] && continue
+      if [[ "${CONN_NAME}" == "${AP_NAME}" ]]; then
+        continue
+      fi
+      MODE=$(nmcli -t -f 802-11-wireless.mode connection show "${CONN_NAME}" 2>/dev/null || echo "")
+      if [[ "${MODE}" == "ap" ]]; then
+        continue
       fi
     fi
-  done <<< "${ACTIVE_CONN}"
+
+    STATE_DETAIL=$(nmcli -t -f GENERAL.STATE device show "${DEVICE}" 2>/dev/null || true)
+    if [[ "${STATE_DETAIL}" == 100* ]]; then
+      HAS_CONNECTIVITY=1
+      LOG "${TYPE^} ${DEVICE} activo (${STATE_DETAIL}); no se requiere ${AP_NAME}"
+      break
+    fi
+  done < <(nmcli -t -f DEVICE,TYPE,STATE device status 2>/dev/null || true)
+else
+  # Fallback sin nmcli: revisar IPs directas
+  if ip -4 addr show | grep -E '^[0-9]+: (eth|wlan)' | grep -q 'inet '; then
+    HAS_CONNECTIVITY=1
+    LOG "Interfaces con IP detectadas sin nmcli; omitiendo ${AP_NAME}"
+  fi
 fi
 
-# If we have connectivity, don't start AP
-if [[ "${HAS_ETH}" -eq 1 ]] || [[ "${HAS_WIFI_CLIENT}" -eq 1 ]]; then
-  LOG "Connectivity available, AP not needed"
+if [[ "${HAS_CONNECTIVITY}" -eq 1 ]]; then
+  LOG "Conectividad presente; no se activa AP"
   exit 0
 fi
 
-# No connectivity, bring up AP
-LOG "No connectivity detected, activating ${AP_NAME}"
-if ! nmcli connection up "${AP_NAME}" 2>&1 | tee -a /var/log/bascula/ap-ensure.log; then
-  LOG "Failed to activate ${AP_NAME}"
+LOG "Sin conectividad a Internet; activando ${AP_NAME}"
+if command -v nmcli >/dev/null 2>&1; then
+  if ! nmcli connection up "${AP_NAME}" >"${TMP_OUTPUT}" 2>&1; then
+    LOG "Fallo al activar ${AP_NAME}"
+    NMCLI_DIAG
+    if ! nmcli connection modify "${AP_NAME}" connection.autoconnect yes connection.autoconnect-priority 100 >/dev/null 2>&1; then
+      LOG "No se pudo forzar autoconnect como respaldo"
+    else
+      LOG "Autoconnect activado como respaldo para ${AP_NAME}"
+    fi
+    if [[ -s "${TMP_OUTPUT}" ]]; then
+      while IFS= read -r line; do LOG "[nmcli] ${line}"; done <"${TMP_OUTPUT}"
+    fi
+    exit 1
+  fi
+  if [[ -s "${TMP_OUTPUT}" ]]; then
+    while IFS= read -r line; do LOG "[nmcli] ${line}"; done <"${TMP_OUTPUT}"
+  fi
+else
+  LOG "nmcli no disponible; imposible activar ${AP_NAME}"
   exit 1
 fi
 
-LOG "${AP_NAME} activated successfully"
+LOG "${AP_NAME} activado correctamente"
 exit 0

--- a/systemd/bascula-ap-ensure.service
+++ b/systemd/bascula-ap-ensure.service
@@ -1,16 +1,12 @@
 [Unit]
-Description=Ensure BasculaAP is active when no other connectivity exists
+Description=Ensure Bascula AP when no other connectivity
 After=NetworkManager.service
-Wants=NetworkManager.service
-ConditionPathExists=/usr/local/sbin/bascula-ap-ensure.sh
+Wants=network-online.target
 
 [Service]
 Type=oneshot
 ExecStart=/usr/local/sbin/bascula-ap-ensure.sh
 RemainAfterExit=yes
-TimeoutSec=20
-StandardOutput=journal
-StandardError=journal
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- adjust install-all.sh to configure the BasculaAP profile without static IPv4 overrides, add detailed nmcli diagnostics, and gate hciuart shutdown on the unit’s presence
- install and start bascula-ap-ensure.service immediately when systemd is available while falling back to autoconnect if the ensure unit cannot be activated
- overhaul bascula-ap-ensure.sh and its unit files to detect existing connectivity, log diagnostics, and trigger nmcli with automatic autoconnect fallback

## Testing
- bash -n scripts/install-all.sh
- bash -n system/os/bascula-ap-ensure.sh

------
https://chatgpt.com/codex/tasks/task_e_68e10992de308326818c64d1e56360d6