### PR TITLE
Ensure Bascula AP fallback is managed by NetworkManager

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -117,7 +117,7 @@ hdmi_cvt=1024 600 60 6 0 0 0
 Si no hay red WiFi al arrancar, el sistema activa automáticamente:
 
 **SSID:** `Bascula-AP`  
-**Password:** `bascula2025`  
+**Password:** `Bascula1234`
 **URL:** `http://192.168.4.1:8080`
 
 Configura desde la mini-web y reinicia.

--- a/MINI_WEB_AND_AP.md
+++ b/MINI_WEB_AND_AP.md
@@ -174,9 +174,26 @@ Editar `systemd/bascula-backend.service` para incluir mini-web si es necesario, 
 
 ### Red AP
 - **SSID**: `Bascula-AP`
-- **Password**: `bascula2025` (WPA2)
+- **Password**: `Bascula1234` (WPA2)
 - **IP Range**: 192.168.4.2 - 192.168.4.20
 - **Aislada**: No accede a internet hasta conectar WiFi
+
+### Flujo esperado
+1. Sin redes conocidas → `BasculaAP` se levanta automáticamente en `wlan0` (`192.168.4.1/24`).
+2. Conecta al AP y abre `http://192.168.4.1:8080` para guardar una Wi-Fi.
+3. Al tener conectividad STA el AP se baja; si se pierde la red, vuelve a aparecer.
+
+### Verificación rápida
+
+```bash
+nmcli -t -f DEVICE,TYPE,STATE,CONNECTION dev status || true
+nmcli -t -f NAME,TYPE,DEVICE con show | grep -E 'BasculaAP|wlan' || true
+nmcli -g connection.interface-name,802-11-wireless.mode,ipv4.method,ipv4.addresses,ipv4.gateway,ipv4.dns con show BasculaAP || true
+journalctl -u bascula-ap-ensure -b | tail -n 20
+ss -lntu | grep ':53' || true
+```
+
+> Recuerda personalizar la contraseña WPA2 (`Bascula1234` por defecto) tras la primera puesta en marcha.
 
 ### Validación
 - Validación de SSID y contraseña en backend
@@ -189,7 +206,7 @@ Editar `systemd/bascula-backend.service` para incluir mini-web si es necesario, 
 
 1. **Conectar al AP**:
    - Red: `Bascula-AP`
-   - Contraseña: `bascula2025`
+   - Contraseña: `Bascula1234`
 
 2. **Acceder a mini-web**:
    - Automático: Algunos dispositivos abren portal captivo

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Incluye:
    - Configura reglas de PolicyKit que permiten al usuario `pi` administrar redes Wi-Fi (escaneo, conexión, y modo compartido). 【F:scripts/install-all.sh†L320-L352】【F:packaging/polkit/49-nmcli.rules†L1-L13】
    - Despliega el backend mini-web (`bascula-miniweb.service`) escuchando en `:8080`. 【F:packaging/systemd/bascula-miniweb.service†L1-L16】
    - Configura el servicio kiosk de Chromium apuntando a `http://localhost:8080`. 【F:scripts/install-all.sh†L772-L834】
-   - Instala y habilita el temporizador de fallback (`bascula-net-fallback`) que activa el AP sólo cuando no hay Wi-Fi ni Ethernet disponibles. 【F:scripts/net-fallback.sh†L1-L152】
+   - Despliega el servicio `bascula-ap-ensure.service`, que crea y activa el AP `BasculaAP` (wlan0, `192.168.4.1/24`) sólo cuando no hay conectividad previa. 【F:scripts/install-all.sh†L1090-L1185】【F:scripts/bascula-ap-ensure.sh†L1-L150】
 
 3. Reinicia el dispositivo al finalizar la instalación para cargar todos los servicios y reglas (`sudo reboot`).
 
@@ -37,6 +37,7 @@ Tras el reinicio:
 - `bascula-miniweb.service` sirve la mini-web y la API en `http://localhost:8080`.
 - `bascula-app.service` lanza Chromium en modo kiosk apuntando a `http://localhost:8080`.
 - El PIN de acceso se muestra en la pantalla principal y puede consultarse desde `/api/miniweb/pin` cuando se accede localmente.
+- Si no hay Wi-Fi ni Ethernet, `bascula-ap-ensure.service` levanta `Bascula-AP` (`192.168.4.1`) con clave `Bascula1234` para exponer la miniweb en `http://192.168.4.1:8080`. 【F:scripts/bascula-ap-ensure.sh†L18-L115】
 
 ## API de configuración de red
 
@@ -56,12 +57,32 @@ Las reglas instaladas permiten al usuario `pi` (o miembros de `netdev`) ejecutar
 
 ### Modo AP de rescate
 
-`scripts/net-fallback.sh` se ejecuta periódicamente y sólo levanta el AP `BasculaAP` (`192.168.4.1`) cuando:
+El modo AP está gestionado íntegramente por NetworkManager:
 
-- No hay conexión Ethernet activa.
-- No se detecta conectividad a Internet mediante Wi-Fi.
+- **SSID**: `Bascula-AP`
+- **Contraseña WPA2**: `Bascula1234`
+- **IP de la báscula**: `192.168.4.1/24`
+- **Miniweb**: `http://192.168.4.1:8080`
 
-Si se detecta Ethernet, el AP se desactiva automáticamente para priorizar la red cableada. 【F:scripts/net-fallback.sh†L30-L134】
+> Cambia esta contraseña en cuanto sea posible desde la miniweb para tu despliegue final.
+
+Flujo esperado:
+
+1. Sin credenciales conocidas → `bascula-ap-ensure.sh` crea/activa la red compartida en `wlan0` con DHCP interno de NetworkManager.
+2. El usuario accede a `http://192.168.4.1:8080`, introduce el PIN y guarda una Wi-Fi doméstica.
+3. Al conectar en modo estación, el AP se baja automáticamente; si la Pi vuelve a quedarse sin conectividad, el AP reaparece.
+
+Verificación rápida (no bloqueante):
+
+```bash
+nmcli -t -f DEVICE,TYPE,STATE,CONNECTION dev status || true
+nmcli -t -f NAME,TYPE,DEVICE con show | grep -E 'BasculaAP|wlan' || true
+nmcli -g connection.interface-name,802-11-wireless.mode,ipv4.method,ipv4.addresses,ipv4.gateway,ipv4.dns con show BasculaAP || true
+journalctl -u bascula-ap-ensure -b | tail -n 20
+ss -lntu | grep ':53' || true   # No debe aparecer dnsmasq.service
+```
+
+Todos estos pasos quedan automatizados por `scripts/bascula-ap-ensure.sh`, ejecutado como servicio `oneshot` con reintentos. 【F:scripts/bascula-ap-ensure.sh†L1-L150】【F:systemd/bascula-ap-ensure.service†L1-L16】
 
 ## Validación recomendada
 
@@ -69,7 +90,7 @@ Si se detecta Ethernet, el AP se desactiva automáticamente para priorizar la re
 2. Desde la mini-web (`/config`) o un navegador en la misma LAN:
    - Ejecuta un escaneo de redes y verifica que se listan SSID, nivel de señal, seguridad y la red actualmente en uso. 【F:src/pages/MiniWebConfig.tsx†L1-L210】
    - Conecta a una red protegida y comprueba que el endpoint responde con éxito y programa el reinicio.
-3. Con Ethernet conectada, asegúrate de que el AP `BasculaAP` no se levanta (el timer lo desactivará si estuviera activo). 【F:scripts/net-fallback.sh†L105-L134】
-4. Si desconectas Ethernet y no hay Wi-Fi válida, el AP `BasculaAP` debe activarse automáticamente para permitir la configuración.
+3. Con Ethernet conectada, revisa que `bascula-ap-ensure` no active el AP (`nmcli -t -f NAME con show --active` no debe listar `BasculaAP`).
+4. Tras desconectar Ethernet y eliminar cualquier Wi-Fi válida, `BasculaAP` debe aparecer con IP `192.168.4.1`. Verifica con los comandos de la sección anterior y consulta los logs con `journalctl -u bascula-ap-ensure -b`.
 
 Con este flujo, una Raspberry Pi recién provisionada queda lista para funcionar sin intervenciones manuales en NetworkManager y con la UI limpia de branding antiguo.

--- a/backend/miniweb.py
+++ b/backend/miniweb.py
@@ -51,7 +51,7 @@ NM_CONNECTIONS_DIR = Path("/etc/NetworkManager/system-connections")
 HOME_CONNECTION_ID = "BasculaHome"
 AP_CONNECTION_ID = "BasculaAP"
 AP_DEFAULT_SSID = "Bascula-AP"
-AP_DEFAULT_PASSWORD = "bascula2025"
+AP_DEFAULT_PASSWORD = "Bascula1234"
 WIFI_INTERFACE = "wlan0"
 
 CFG_DIR.mkdir(parents=True, exist_ok=True)

--- a/scripts/bascula-ap-ensure.sh
+++ b/scripts/bascula-ap-ensure.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# Ensure BasculaAP comes up on wlan0 when no other connectivity is available.
+# Compatible with systems with or without systemd.
+
+set -euo pipefail
+
+TMP_LOG="$(mktemp -t bascula-ap-ensure.XXXXXX 2>/dev/null || printf '/tmp/bascula-ap-ensure.%s' "$$")"
+
+trap 'logger -t bascula-ap-ensure "error en línea $LINENO"; echo "[bascula-ap-ensure] error en línea $LINENO" >&2' ERR
+trap 'rm -f "${TMP_LOG}" 2>/dev/null || true' EXIT
+
+log() {
+  logger -t bascula-ap-ensure -- "$1" 2>/dev/null || true
+  printf '[bascula-ap-ensure] %s\n' "$1"
+}
+
+AP_NAME="${AP_NAME:-BasculaAP}"
+AP_IFACE="${AP_IFACE:-wlan0}"
+AP_SSID="${AP_SSID:-Bascula-AP}"
+AP_PASS_DEFAULT="Bascula1234"
+AP_PASS="${AP_PASS:-${AP_PASS_DEFAULT}}"
+AP_GATEWAY="${AP_GATEWAY:-192.168.4.1}"
+AP_CIDR="${AP_GATEWAY}/24"
+
+has_connectivity=0
+if command -v nmcli >/dev/null 2>&1; then
+  state="$(nmcli -t -f STATE general status 2>/dev/null || true)"
+  [[ "${state}" == "connected" ]] && has_connectivity=1
+  if [[ "${has_connectivity}" -eq 0 ]]; then
+    connectivity="$(nmcli networking connectivity check 2>/dev/null || true)"
+    case "${connectivity}" in
+      full|internet)
+        has_connectivity=1
+        ;;
+    esac
+  fi
+fi
+
+if [[ "${has_connectivity}" -eq 0 ]] && ip -4 route show default >/dev/null 2>&1; then
+  has_connectivity=1
+fi
+
+if [[ "${has_connectivity}" -eq 1 ]]; then
+  log "Conectividad detectada; asegurando que ${AP_NAME} esté bajada"
+  if command -v nmcli >/dev/null 2>&1; then
+    if nmcli -t -f NAME con show --active 2>/dev/null | grep -qx "${AP_NAME}"; then
+      if nmcli connection down "${AP_NAME}" >/dev/null 2>&1; then
+        log "${AP_NAME} desactivada por conectividad activa"
+      fi
+    fi
+  fi
+  exit 0
+fi
+
+if ! command -v nmcli >/dev/null 2>&1; then
+  log "nmcli requerido para gestionar ${AP_NAME}; abortando"
+  exit 1
+fi
+
+log "Sin conectividad; preparando ${AP_NAME} en ${AP_IFACE}"
+rfkill unblock wifi 2>/dev/null || true
+nmcli radio wifi on >/dev/null 2>&1 || true
+
+ensure_profile() {
+  local recreate=0
+  if ! nmcli connection show "${AP_NAME}" >/dev/null 2>&1; then
+    recreate=1
+  else
+    local iface mode ipv4_method ipv4_addr ipv4_gw ipv4_dns
+    iface="$(nmcli -g connection.interface-name connection show "${AP_NAME}" 2>/dev/null || echo '')"
+    mode="$(nmcli -g 802-11-wireless.mode connection show "${AP_NAME}" 2>/dev/null || echo '')"
+    ipv4_method="$(nmcli -g ipv4.method connection show "${AP_NAME}" 2>/dev/null || echo '')"
+    ipv4_addr="$(nmcli -g ipv4.addresses connection show "${AP_NAME}" 2>/dev/null || echo '')"
+    ipv4_gw="$(nmcli -g ipv4.gateway connection show "${AP_NAME}" 2>/dev/null || echo '')"
+    ipv4_dns="$(nmcli -g ipv4.dns connection show "${AP_NAME}" 2>/dev/null || echo '')"
+    [[ "${iface}" != "${AP_IFACE}" ]] && recreate=1
+    [[ "${mode}" != "ap" ]] && recreate=1
+    [[ "${ipv4_method}" != "shared" ]] && recreate=1
+    [[ "${ipv4_addr}" != "${AP_CIDR}" ]] && recreate=1
+    [[ "${ipv4_gw}" != "${AP_GATEWAY}" ]] && recreate=1
+    [[ -n "${ipv4_dns}" ]] && recreate=1
+  fi
+
+  if [[ "${recreate}" -eq 0 ]]; then
+    local existing_psk
+    existing_psk="$(nmcli -s -g wifi-sec.psk connection show "${AP_NAME}" 2>/dev/null || echo '')"
+    [[ -n "${existing_psk}" ]] && AP_PASS="${existing_psk}"
+    nmcli connection modify "${AP_NAME}" connection.autoconnect yes connection.autoconnect-priority 100 >/dev/null 2>&1 || true
+    return 0
+  fi
+
+  log "Recreando perfil ${AP_NAME}"
+  nmcli connection delete "${AP_NAME}" >/dev/null 2>&1 || true
+  if ! nmcli connection add type wifi ifname "${AP_IFACE}" con-name "${AP_NAME}" ssid "${AP_SSID}" >/dev/null 2>&1; then
+    log "Error al crear el perfil ${AP_NAME}"
+    return 1
+  fi
+
+  nmcli connection modify "${AP_NAME}" \
+    connection.interface-name "${AP_IFACE}" \
+    802-11-wireless.mode ap \
+    802-11-wireless.band bg \
+    ipv4.method shared \
+    ipv4.addresses "${AP_CIDR}" \
+    ipv4.gateway "${AP_GATEWAY}" \
+    ipv4.never-default yes \
+    -ipv4.dns \
+    ipv6.method ignore >/dev/null 2>&1 || return 1
+
+  if [[ -n "${AP_PASS}" ]]; then
+    nmcli connection modify "${AP_NAME}" wifi-sec.key-mgmt wpa-psk wifi-sec.psk "${AP_PASS}" >/dev/null 2>&1 || return 1
+  else
+    nmcli connection modify "${AP_NAME}" wifi-sec.key-mgmt none >/dev/null 2>&1 || return 1
+  fi
+
+  nmcli connection modify "${AP_NAME}" connection.autoconnect yes connection.autoconnect-priority 100 >/dev/null 2>&1 || return 1
+  return 0
+}
+
+if ! ensure_profile; then
+  log "No se pudo asegurar el perfil ${AP_NAME}"
+  exit 1
+fi
+
+if [[ -d /run/systemd/system ]] && command -v systemctl >/dev/null 2>&1; then
+  systemctl disable --now dnsmasq 2>/dev/null || true
+else
+  if command -v service >/dev/null 2>&1; then
+    service dnsmasq stop >/dev/null 2>&1 || true
+  fi
+fi
+
+log "Activando ${AP_NAME}"
+if nmcli connection up "${AP_NAME}" ifname "${AP_IFACE}" >"${TMP_LOG}" 2>&1; then
+  while IFS= read -r line; do log "${line}"; done < "${TMP_LOG}" || true
+  log "${AP_NAME} activo en ${AP_IFACE} (${AP_CIDR})"
+  exit 0
+fi
+
+log "Fallo al activar ${AP_NAME}"
+if [[ -s "${TMP_LOG}" ]]; then
+  while IFS= read -r line; do log "${line}"; done < "${TMP_LOG}" || true
+fi
+exit 1

--- a/scripts/migrate_2025_10.sh
+++ b/scripts/migrate_2025_10.sh
@@ -48,7 +48,7 @@ mode=ap
 
 [wifi-security]
 key-mgmt=wpa-psk
-psk=bascula2025
+psk=Bascula1234
 
 [ipv4]
 method=shared

--- a/scripts/net-fallback.sh
+++ b/scripts/net-fallback.sh
@@ -11,7 +11,7 @@ log() { logger -t bascula-net-fallback "$*"; }
 
 # Configuración
 AP_SSID="${AP_SSID:-Bascula-AP}"
-AP_PASS="${AP_PASS:-bascula2025}"
+AP_PASS="${AP_PASS:-Bascula1234}"
 AP_IFACE="${AP_IFACE:-wlan0}"
 AP_NAME="${AP_NAME:-BasculaAP}"
 AP_GATEWAY="${AP_GATEWAY:-192.168.4.1}"
@@ -81,7 +81,8 @@ create_ap_profile() {
     ipv4.method shared \
     ipv4.addresses "${AP_GATEWAY}/24" \
     ipv4.gateway "${AP_GATEWAY}" \
-    ipv4.dns "${AP_GATEWAY}" \
+    ipv4.never-default yes \
+    -ipv4.dns \
     ipv6.method ignore 2>/dev/null; then
     return 1
   fi

--- a/scripts/setup-ap-mode.sh
+++ b/scripts/setup-ap-mode.sh
@@ -43,7 +43,7 @@ macaddr_acl=0
 auth_algs=1
 ignore_broadcast_ssid=0
 wpa=2
-wpa_passphrase=bascula2025
+wpa_passphrase=Bascula1234
 wpa_key_mgmt=WPA-PSK
 wpa_pairwise=TKIP
 rsn_pairwise=CCMP
@@ -78,7 +78,7 @@ sudo systemctl disable dnsmasq
 
 echo "✅ Modo AP configurado"
 echo "📡 SSID: Bascula-AP"
-echo "🔐 Password: bascula2025"
+echo "🔐 Password: Bascula1234"
 echo "📍 IP: 192.168.4.1"
 echo ""
 echo "⚠️  Los servicios NO se inician automáticamente"

--- a/src/components/APModeScreen.tsx
+++ b/src/components/APModeScreen.tsx
@@ -5,7 +5,7 @@ import { Card } from "@/components/ui/card";
 
 export const APModeScreen = () => {
   const apSSID = "Bascula-AP";
-  const apPassword = "bascula2025";
+  const apPassword = "Bascula1234";
   const miniWebURL = "http://192.168.4.1:8080";
   const [miniWebPin, setMiniWebPin] = useState<string | null>(null);
   const [pinMessage, setPinMessage] = useState<string | null>(null);

--- a/system/os/bascula-ap-ensure.service
+++ b/system/os/bascula-ap-ensure.service
@@ -1,12 +1,13 @@
 [Unit]
 Description=Ensure Bascula AP when no other connectivity
 After=NetworkManager.service
-Wants=network-online.target
+Wants=NetworkManager.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/sbin/bascula-ap-ensure.sh
-RemainAfterExit=yes
+ExecStart=/opt/bascula/current/scripts/bascula-ap-ensure.sh
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/system/os/nm/BasculaAP.nmconnection
+++ b/system/os/nm/BasculaAP.nmconnection
@@ -14,11 +14,10 @@ band=bg
 
 [wifi-security]
 key-mgmt=wpa-psk
-psk=bascula2025
+psk=Bascula1234
 
 [ipv4]
 address1=192.168.4.1/24
-dns=1.1.1.1;8.8.8.8;
 gateway=192.168.4.1
 method=shared
 

--- a/systemd/bascula-ap-ensure.service
+++ b/systemd/bascula-ap-ensure.service
@@ -1,12 +1,13 @@
 [Unit]
 Description=Ensure Bascula AP when no other connectivity
 After=NetworkManager.service
-Wants=network-online.target
+Wants=NetworkManager.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/sbin/bascula-ap-ensure.sh
-RemainAfterExit=yes
+ExecStart=/opt/bascula/current/scripts/bascula-ap-ensure.sh
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- recreate the BasculaAP NetworkManager profile during install with deterministic 192.168.4.1/24 shared addressing, no ipv4.dns override and wifi enabled on wlan0
- add a oneshot `scripts/bascula-ap-ensure.sh` service that repairs the profile, disables any global dnsmasq instance and raises the AP only when connectivity is absent
- document the AP flow (SSID Bascula-AP, PSK Bascula1234, miniweb on 192.168.4.1:8080) and surface quick verification commands; align backend/UI defaults with the new PSK

## Rationale
- keeping 192.168.4.1/24 under `ipv4.method shared` restores the stable address expected by the miniweb, kiosk UI and mobile clients while letting NetworkManager hand out DHCP leases.
- leaving `ipv4.dns` empty avoids the warning and allows the embedded dnsmasq instance spawned by NetworkManager to bind to :53 without conflicts.
- disabling/stopping the standalone `dnsmasq.service` ensures no external daemon competes for :53, so NM's internal DHCP/DNS works reliably.
- on devices without systemd we rely on `connection.autoconnect yes` and priority 100, while systemd nodes enable the oneshot `bascula-ap-ensure.service` with retries.

## Quick verification
```bash
nmcli -t -f DEVICE,TYPE,STATE,CONNECTION dev status || true
nmcli -t -f NAME,TYPE,DEVICE con show | grep -E 'BasculaAP|wlan' || true
nmcli -g connection.interface-name,802-11-wireless.mode,ipv4.method,ipv4.addresses,ipv4.gateway,ipv4.dns con show BasculaAP || true
journalctl -u bascula-ap-ensure -b | tail -n 20
ss -lntu | grep ':53' || true
```

## Testing
- not run (infrastructure changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e10d0812908326a1fd1b282b2bda99