### PR TITLE
Ensure Bascula AP configuration always uses wlan0 shared mode

### DIFF
--- a/MINI_WEB_AND_AP.md
+++ b/MINI_WEB_AND_AP.md
@@ -178,6 +178,9 @@ Editar `systemd/bascula-backend.service` para incluir mini-web si es necesario, 
 - **IP Range**: 192.168.4.2 - 192.168.4.20
 - **Aislada**: No accede a internet hasta conectar WiFi
 
+> Personaliza la contraseña exportando `AP_PASS="<tu_clave>"` antes de ejecutar el instalador o con
+> `nmcli con modify BasculaAP wifi-sec.psk <nueva_clave>` tras la instalación.
+
 ### Flujo esperado
 1. Sin redes conocidas → `BasculaAP` se levanta automáticamente en `wlan0` (`192.168.4.1/24`).
 2. Conecta al AP y abre `http://192.168.4.1:8080` para guardar una Wi-Fi.
@@ -186,9 +189,8 @@ Editar `systemd/bascula-backend.service` para incluir mini-web si es necesario, 
 ### Verificación rápida
 
 ```bash
-nmcli -t -f DEVICE,TYPE,STATE,CONNECTION dev status || true
-nmcli -t -f NAME,TYPE,DEVICE con show | grep -E 'BasculaAP|wlan' || true
-nmcli -g connection.interface-name,802-11-wireless.mode,ipv4.method,ipv4.addresses,ipv4.gateway,ipv4.dns con show BasculaAP || true
+nmcli dev status
+nmcli -g connection.interface-name,802-11-wireless.mode,ipv4.method,ipv4.addresses,ipv4.gateway con show BasculaAP
 journalctl -u bascula-ap-ensure -b | tail -n 20
 ss -lntu | grep ':53' || true
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Las reglas instaladas permiten al usuario `pi` (o miembros de `netdev`) ejecutar
 El modo AP está gestionado íntegramente por NetworkManager:
 
 - **SSID**: `Bascula-AP`
-- **Contraseña WPA2**: `Bascula1234`
+- **Contraseña WPA2**: `Bascula1234` (puedes personalizarla exportando `AP_PASS="<tu_clave>"` antes de ejecutar el instalador o con
+  `nmcli con modify BasculaAP wifi-sec.psk <nueva_clave>` tras la instalación).
 - **IP de la báscula**: `192.168.4.1/24`
 - **Miniweb**: `http://192.168.4.1:8080`
 
@@ -75,9 +76,8 @@ Flujo esperado:
 Verificación rápida (no bloqueante):
 
 ```bash
-nmcli -t -f DEVICE,TYPE,STATE,CONNECTION dev status || true
-nmcli -t -f NAME,TYPE,DEVICE con show | grep -E 'BasculaAP|wlan' || true
-nmcli -g connection.interface-name,802-11-wireless.mode,ipv4.method,ipv4.addresses,ipv4.gateway,ipv4.dns con show BasculaAP || true
+nmcli dev status
+nmcli -g connection.interface-name,802-11-wireless.mode,ipv4.method,ipv4.addresses,ipv4.gateway con show BasculaAP
 journalctl -u bascula-ap-ensure -b | tail -n 20
 ss -lntu | grep ':53' || true   # No debe aparecer dnsmasq.service
 ```

--- a/scripts/bascula-ap-ensure.sh
+++ b/scripts/bascula-ap-ensure.sh
@@ -16,47 +16,30 @@ log() {
 }
 
 AP_NAME="${AP_NAME:-BasculaAP}"
-AP_IFACE="${AP_IFACE:-wlan0}"
+AP_IFACE="wlan0"
 AP_SSID="${AP_SSID:-Bascula-AP}"
 AP_PASS_DEFAULT="Bascula1234"
 AP_PASS="${AP_PASS:-${AP_PASS_DEFAULT}}"
-AP_GATEWAY="${AP_GATEWAY:-192.168.4.1}"
+AP_GATEWAY="192.168.4.1"
 AP_CIDR="${AP_GATEWAY}/24"
-
-has_connectivity=0
-if command -v nmcli >/dev/null 2>&1; then
-  state="$(nmcli -t -f STATE general status 2>/dev/null || true)"
-  [[ "${state}" == "connected" ]] && has_connectivity=1
-  if [[ "${has_connectivity}" -eq 0 ]]; then
-    connectivity="$(nmcli networking connectivity check 2>/dev/null || true)"
-    case "${connectivity}" in
-      full|internet)
-        has_connectivity=1
-        ;;
-    esac
-  fi
-fi
-
-if [[ "${has_connectivity}" -eq 0 ]] && ip -4 route show default >/dev/null 2>&1; then
-  has_connectivity=1
-fi
-
-if [[ "${has_connectivity}" -eq 1 ]]; then
-  log "Conectividad detectada; asegurando que ${AP_NAME} esté bajada"
-  if command -v nmcli >/dev/null 2>&1; then
-    if nmcli -t -f NAME con show --active 2>/dev/null | grep -qx "${AP_NAME}"; then
-      if nmcli connection down "${AP_NAME}" >/dev/null 2>&1; then
-        log "${AP_NAME} desactivada por conectividad activa"
-      fi
-    fi
-  fi
-  exit 0
-fi
 
 if ! command -v nmcli >/dev/null 2>&1; then
   log "nmcli requerido para gestionar ${AP_NAME}; abortando"
   exit 1
 fi
+
+connectivity="$(nmcli networking connectivity check 2>/dev/null || echo 'unknown')"
+case "${connectivity}" in
+  full|internet|portal|limited)
+    log "Conectividad (${connectivity}); bajando ${AP_NAME} si está activo"
+    if nmcli -t -f NAME con show --active 2>/dev/null | grep -qx "${AP_NAME}"; then
+      if nmcli connection down "${AP_NAME}" >/dev/null 2>&1; then
+        log "${AP_NAME} desactivada por conectividad existente"
+      fi
+    fi
+    exit 0
+    ;;
+esac
 
 log "Sin conectividad; preparando ${AP_NAME} en ${AP_IFACE}"
 rfkill unblock wifi 2>/dev/null || true
@@ -67,53 +50,57 @@ ensure_profile() {
   if ! nmcli connection show "${AP_NAME}" >/dev/null 2>&1; then
     recreate=1
   else
-    local iface mode ipv4_method ipv4_addr ipv4_gw ipv4_dns
+    local iface mode ipv4_method ipv4_addr ipv4_gw ipv4_dns key_mgmt
     iface="$(nmcli -g connection.interface-name connection show "${AP_NAME}" 2>/dev/null || echo '')"
     mode="$(nmcli -g 802-11-wireless.mode connection show "${AP_NAME}" 2>/dev/null || echo '')"
     ipv4_method="$(nmcli -g ipv4.method connection show "${AP_NAME}" 2>/dev/null || echo '')"
-    ipv4_addr="$(nmcli -g ipv4.addresses connection show "${AP_NAME}" 2>/dev/null || echo '')"
+    ipv4_addr="$(nmcli -g ipv4.addresses connection show "${AP_NAME}" 2>/dev/null | head -n1 || echo '')"
     ipv4_gw="$(nmcli -g ipv4.gateway connection show "${AP_NAME}" 2>/dev/null || echo '')"
     ipv4_dns="$(nmcli -g ipv4.dns connection show "${AP_NAME}" 2>/dev/null || echo '')"
+    key_mgmt="$(nmcli -g wifi-sec.key-mgmt connection show "${AP_NAME}" 2>/dev/null || echo '')"
     [[ "${iface}" != "${AP_IFACE}" ]] && recreate=1
     [[ "${mode}" != "ap" ]] && recreate=1
     [[ "${ipv4_method}" != "shared" ]] && recreate=1
     [[ "${ipv4_addr}" != "${AP_CIDR}" ]] && recreate=1
     [[ "${ipv4_gw}" != "${AP_GATEWAY}" ]] && recreate=1
     [[ -n "${ipv4_dns}" ]] && recreate=1
+    [[ "${key_mgmt}" != "wpa-psk" ]] && recreate=1
   fi
 
+  local effective_psk="${AP_PASS}"
   if [[ "${recreate}" -eq 0 ]]; then
     local existing_psk
     existing_psk="$(nmcli -s -g wifi-sec.psk connection show "${AP_NAME}" 2>/dev/null || echo '')"
-    [[ -n "${existing_psk}" ]] && AP_PASS="${existing_psk}"
+    [[ -n "${existing_psk}" ]] && effective_psk="${existing_psk}"
     nmcli connection modify "${AP_NAME}" connection.autoconnect yes connection.autoconnect-priority 100 >/dev/null 2>&1 || true
     return 0
   fi
 
   log "Recreando perfil ${AP_NAME}"
+  local previous_psk
+  previous_psk="$(nmcli -s -g wifi-sec.psk connection show "${AP_NAME}" 2>/dev/null || echo '')"
+  [[ -n "${previous_psk}" ]] && effective_psk="${previous_psk}"
+
   nmcli connection delete "${AP_NAME}" >/dev/null 2>&1 || true
+  nmcli con delete "BasculaAP" >/dev/null 2>&1 || true
+  sudo rm -f /etc/NetworkManager/system-connections/BasculaAP.nmconnection 2>/dev/null || true
+
   if ! nmcli connection add type wifi ifname "${AP_IFACE}" con-name "${AP_NAME}" ssid "${AP_SSID}" >/dev/null 2>&1; then
     log "Error al crear el perfil ${AP_NAME}"
+    nmcli dev status || true
+    nmcli -t -f NAME,TYPE,DEVICE con show || true
+    nmcli -g connection.interface-name,802-11-wireless.mode,ipv4.method,ipv4.addresses,ipv4.gateway,ipv4.dns con show "${AP_NAME}" || true
     return 1
   fi
 
-  nmcli connection modify "${AP_NAME}" \
-    connection.interface-name "${AP_IFACE}" \
-    802-11-wireless.mode ap \
-    802-11-wireless.band bg \
-    ipv4.method shared \
-    ipv4.addresses "${AP_CIDR}" \
-    ipv4.gateway "${AP_GATEWAY}" \
-    ipv4.never-default yes \
-    -ipv4.dns \
-    ipv6.method ignore >/dev/null 2>&1 || return 1
+  nmcli connection modify "${AP_NAME}" connection.interface-name "${AP_IFACE}" 802-11-wireless.mode ap 802-11-wireless.band bg >/dev/null 2>&1 || return 1
+  nmcli connection modify "${AP_NAME}" ipv4.method shared ipv4.addresses "${AP_CIDR}" ipv4.gateway "${AP_GATEWAY}" ipv4.never-default yes >/dev/null 2>&1 || return 1
+  nmcli connection modify "${AP_NAME}" -ipv4.dns >/dev/null 2>&1 || true
+  nmcli connection modify "${AP_NAME}" ipv6.method ignore >/dev/null 2>&1 || true
+  nmcli connection modify "${AP_NAME}" wifi-sec.key-mgmt wpa-psk >/dev/null 2>&1 || return 1
 
-  if [[ -n "${AP_PASS}" ]]; then
-    nmcli connection modify "${AP_NAME}" wifi-sec.key-mgmt wpa-psk wifi-sec.psk "${AP_PASS}" >/dev/null 2>&1 || return 1
-  else
-    nmcli connection modify "${AP_NAME}" wifi-sec.key-mgmt none >/dev/null 2>&1 || return 1
-  fi
-
+  [[ -z "${effective_psk}" ]] && effective_psk="${AP_PASS_DEFAULT}"
+  nmcli connection modify "${AP_NAME}" wifi-sec.psk "${effective_psk}" >/dev/null 2>&1 || return 1
   nmcli connection modify "${AP_NAME}" connection.autoconnect yes connection.autoconnect-priority 100 >/dev/null 2>&1 || return 1
   return 0
 }
@@ -123,23 +110,34 @@ if ! ensure_profile; then
   exit 1
 fi
 
-if [[ -d /run/systemd/system ]] && command -v systemctl >/dev/null 2>&1; then
+if command -v systemctl >/dev/null 2>&1 && [[ -d /run/systemd/system ]]; then
   systemctl disable --now dnsmasq 2>/dev/null || true
-else
-  if command -v service >/dev/null 2>&1; then
-    service dnsmasq stop >/dev/null 2>&1 || true
-  fi
+elif command -v service >/dev/null 2>&1; then
+  service dnsmasq stop >/dev/null 2>&1 || true
+fi
+
+if ! nmcli dev status 2>/dev/null | awk -v iface="${AP_IFACE}" 'NR>1 && $1 == iface {found=1} END {exit found?0:1}'; then
+  log "Interfaz ${AP_IFACE} no listada por nmcli; reintento posterior"
+  exit 75
 fi
 
 log "Activando ${AP_NAME}"
 if nmcli connection up "${AP_NAME}" ifname "${AP_IFACE}" >"${TMP_LOG}" 2>&1; then
   while IFS= read -r line; do log "${line}"; done < "${TMP_LOG}" || true
+  sleep 1
   log "${AP_NAME} activo en ${AP_IFACE} (${AP_CIDR})"
   exit 0
 fi
 
-log "Fallo al activar ${AP_NAME}"
+rc=$?
+log "Fallo al activar ${AP_NAME} (rc=${rc})"
 if [[ -s "${TMP_LOG}" ]]; then
   while IFS= read -r line; do log "${line}"; done < "${TMP_LOG}" || true
 fi
-exit 1
+
+if grep -qiE 'No device|not find device|not available|device not managed' "${TMP_LOG}" 2>/dev/null; then
+  log "Interfaz ${AP_IFACE} no disponible; reintento posterior"
+  exit 75
+fi
+
+exit "${rc}"


### PR DESCRIPTION
## Summary
- add a safe_install helper and rebuild the BasculaAP profile via nmcli on wlan0 with shared IPv4, no dns, and dnsmasq disabled during install
- harden bascula-ap-ensure.sh to drop the AP when connectivity exists, recreate the profile if settings drift, and tolerate missing wifi drivers while logging
- document SSID/PSK/IP defaults, how to change the PSK, and the updated verification commands for quick AP checks

## Testing
- bash -n scripts/install-all.sh
- bash -n scripts/bascula-ap-ensure.sh

------
https://chatgpt.com/codex/tasks/task_e_68e111801b308326ab0ae8affbce86c1