### PR TITLE
Restore nm-online ignore failure for AP ensure service

### DIFF
--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -1212,7 +1212,9 @@ else
 fi
 
 if [[ "${HAS_SYSTEMD}" -eq 1 ]]; then
-  systemctl daemon-reload
+  if ! systemctl daemon-reload; then
+    warn "systemctl daemon-reload falló"
+  fi
   if [[ "${AP_ENSURE_SERVICE_INSTALLED}" -eq 1 ]]; then
     if systemctl enable --now bascula-ap-ensure.service; then
       log "✓ Servicio bascula-ap-ensure habilitado"

--- a/systemd/bascula-ap-ensure.service
+++ b/systemd/bascula-ap-ensure.service
@@ -7,10 +7,13 @@ Wants=network-online.target
 Type=oneshot
 Environment=AP_ENSURE_CONNECTING_WAIT=45
 Environment=AP_ENSURE_CONNECTING_STEP=3
-ExecStartPre=/usr/bin/nm-online -s -q -t 25
+# Ignore nm-online failure so the ensure script can still run
+ExecStartPre=-/usr/bin/nm-online -s -q -t 25
 ExecStart=/opt/bascula/current/scripts/bascula-ap-ensure.sh
 Restart=on-failure
 RestartSec=5s
+StartLimitIntervalSec=300
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- ensure the bascula AP ensure service ignores nm-online failures and adds start limit guards
- make install script resilient when reloading and enabling the service during installation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1195f46008326b78ce4bd155a5562