### PR TITLE
Refine Bascula AP fallback handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ ss -lntu | grep ':53' || true   # No debe aparecer dnsmasq.service
 
 Todos estos pasos quedan automatizados por `scripts/bascula-ap-ensure.sh`, ejecutado como servicio `oneshot` con reintentos. 【F:scripts/bascula-ap-ensure.sh†L1-L150】【F:systemd/bascula-ap-ensure.service†L1-L16】
 
+Checklist posterior a la instalación:
+
+1. Tras ejecutar el instalador, confirma que `BasculaAP` no tiene autoconexión: `nmcli con show | grep BasculaAP` debe mostrar `autoconnect=no`.
+2. Arranca sin cable Ethernet ni Wi-Fi guardada y verifica que el ensure levanta `BasculaAP` (SSID `Bascula-AP`).
+3. Usa la miniweb para guardar una Wi-Fi válida; la AP debe bajar y la interfaz cambiar al modo normal tras obtener IP del router.
+4. En un arranque posterior con esa Wi-Fi guardada, NetworkManager debe conectar al perfil cliente (prioridad 120) sin levantar la AP; si por cualquier motivo `BasculaAP` aparece activa, el ensure la apagará automáticamente al detectar conectividad.
+
 ## Validación recomendada
 
 1. Tras una instalación limpia y reinicio, abre `http://localhost:8080` desde el propio dispositivo y confirma que se muestra el PIN de acceso.

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -749,7 +749,7 @@ if command -v nmcli >/dev/null 2>&1; then
     nmcli con modify "${AP_NAME}" wifi-sec.psk "${ap_psk}" >/dev/null 2>&1 || warn "No se pudo configurar wifi-sec.psk"
   fi
 
-  if ! nmcli con modify "${AP_NAME}" connection.autoconnect yes >/dev/null 2>&1; then
+  if ! nmcli con modify "${AP_NAME}" connection.autoconnect no >/dev/null 2>&1; then
     warn "No se pudo establecer autoconnect en ${AP_NAME}"
   fi
   nmcli con modify "${AP_NAME}" connection.autoconnect-priority 100 >/dev/null 2>&1 || warn "No se pudo establecer prioridad"
@@ -823,8 +823,8 @@ if command -v nmcli >/dev/null 2>&1; then
 fi
 
 # Nota: La UI, al conectar a una nueva Wi-Fi, deberá:
-#  - crear/actualizar esa conexión con autoconnect=yes y prioridad 200
-#  - poner BasculaAP autoconnect=no (para no competir)
+#  - crear/actualizar esa conexión con autoconnect=yes y prioridad 120
+#  - mantener BasculaAP con autoconnect=no (para no competir)
 
 if ! nmcli general status >/dev/null 2>&1; then
   err "ERR: nmcli no responde"

--- a/systemd/bascula-ap-ensure.service
+++ b/systemd/bascula-ap-ensure.service
@@ -2,6 +2,8 @@
 Description=Ensure Bascula AP when no other connectivity
 After=NetworkManager.service NetworkManager-wait-online.service
 Wants=network-online.target
+StartLimitIntervalSec=300
+StartLimitBurst=3
 
 [Service]
 Type=oneshot
@@ -12,8 +14,6 @@ ExecStartPre=-/usr/bin/nm-online -s -q -t 25
 ExecStart=/opt/bascula/current/scripts/bascula-ap-ensure.sh
 Restart=on-failure
 RestartSec=5s
-StartLimitIntervalSec=300
-StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- ensure the installer leaves BasculaAP with autoconnect disabled and document the post-install verification checklist
- teach the bascula-ap-ensure script to drop the AP when a client profile can take over and to keep the AP profile consistent
- update the miniweb Wi-Fi flow to restart the kiosk after a successful client connection, simplify the disable-ap endpoint, and move systemd start limits to [Unit]

## Testing
- python -m compileall backend/miniweb.py

------
https://chatgpt.com/codex/tasks/task_e_68e12746c7ac83268a9b833343b91936