### PR TITLE
Ensure NM profiles persist and refine AP fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Flujo esperado:
 
 1. Sin credenciales conocidas → `bascula-ap-ensure.sh` crea/activa la red compartida en `wlan0` con DHCP interno de NetworkManager.
 2. El usuario accede a `http://192.168.4.1:8080`, introduce el PIN y guarda una Wi-Fi doméstica.
-3. Al enviar SSID y clave desde la miniweb, la Pi recrea el perfil Wi-Fi (prioridad `120`), desconecta `BasculaAP` y conmuta a la red doméstica; si más tarde se pierde la conectividad, el AP reaparece.
+3. Al enviar SSID y clave desde la miniweb, la Pi recrea el perfil Wi-Fi, lo exporta a `/etc/NetworkManager/system-connections/<SSID>.nmconnection` (permisos `600`, `autoconnect=yes`, prioridad `120`), desconecta `BasculaAP`, activa la red doméstica y reinicia el kiosk. Si más tarde se pierde la conectividad, el AP reaparece.
 
 Verificación rápida (no bloqueante):
 

--- a/scripts/bascula-ap-ensure.sh
+++ b/scripts/bascula-ap-ensure.sh
@@ -1,220 +1,223 @@
 #!/usr/bin/env bash
 #
 # Ensure BasculaAP comes up on wlan0 when no other connectivity is available.
-# Compatible with systems with or without systemd.
 
 set -euo pipefail
 
-TMP_LOG="$(mktemp -t bascula-ap-ensure.XXXXXX 2>/dev/null || printf '/tmp/bascula-ap-ensure.%s' "$$")"
-
-trap 'logger -t bascula-ap-ensure "error en línea $LINENO"; echo "[bascula-ap-ensure] error en línea $LINENO" >&2' ERR
-trap 'rm -f "${TMP_LOG}" 2>/dev/null || true' EXIT
-
 log() {
-  logger -t bascula-ap-ensure -- "$1" 2>/dev/null || true
-  printf '[bascula-ap-ensure] %s\n' "$1"
+  local msg="$1"
+  logger -t bascula-ap-ensure -- "$msg" 2>/dev/null || true
+  printf '[bascula-ap-ensure] %s\n' "$msg"
 }
 
+trap 'logger -t bascula-ap-ensure "error en línea $LINENO"; exit 1' ERR
+
 AP_NAME="${AP_NAME:-BasculaAP}"
-AP_IFACE="wlan0"
 AP_SSID="${AP_SSID:-Bascula-AP}"
 AP_PASS_DEFAULT="Bascula1234"
 AP_PASS="${AP_PASS:-${AP_PASS_DEFAULT}}"
+AP_IFACE="wlan0"
 AP_GATEWAY="192.168.4.1"
 AP_CIDR="${AP_GATEWAY}/24"
+AP_KEYFILE="/etc/NetworkManager/system-connections/${AP_NAME}.nmconnection"
+
+nm-online -s -q -t 25 || true
 
 if ! command -v nmcli >/dev/null 2>&1; then
-  log "nmcli requerido para gestionar ${AP_NAME}; abortando"
+  log "nmcli requerido pero no disponible; abortando"
   exit 1
 fi
 
+has_connectivity() {
+  local status
+  status=$(nmcli networking connectivity check 2>/dev/null || echo unknown)
+  status=${status,,}
+  case "${status}" in
+    full|portal|limited|local)
+      return 0
+      ;;
+  esac
+  return 1
+}
 
-: "${AP_ENSURE_CONNECTING_WAIT:=45}"
-: "${AP_ENSURE_CONNECTING_STEP:=3}"
+list_client_profiles() {
+  nmcli -t -f NAME,TYPE,802-11-wireless.mode,connection.autoconnect connection show 2>/dev/null |
+    awk -F: -v ap="${AP_NAME}" 'tolower($2)=="802-11-wireless" && tolower($3)=="infrastructure" && tolower($4)=="yes" && $1!=ap {print $1}'
+}
 
-state_raw="$(nmcli -t -f STATE g 2>/dev/null || echo disconnected)"
-state_lc="$(printf '%s' "${state_raw}" | tr '[:upper:]' '[:lower:]')"
-
-if [[ "${state_lc}" == connected* ]]; then
-  connectivity_lc="$(nmcli networking connectivity check 2>/dev/null | tr '[:upper:]' '[:lower:]' || echo unknown)"
-  active_conn="$(nmcli -t -f DEVICE,STATE,CONNECTION device status 2>/dev/null | awk -F: -v iface="${AP_IFACE}" '$1==iface {print $4; exit}')"
-  if [[ "${active_conn}" == "${AP_NAME}" ]]; then
-    client_profile="$(nmcli -t -f NAME,TYPE,802-11-wireless.mode,connection.autoconnect connection show 2>/dev/null | awk -F: 'tolower($2)=="802-11-wireless" && tolower($3)=="infrastructure" && tolower($4)=="yes" {print $1; exit}')"
-    if [[ -n "${client_profile}" ]]; then
-      log "Conectividad ${connectivity_lc:-unknown} con ${AP_NAME} activo; intentando conmutar a perfil cliente (${client_profile})"
-      nmcli connection down "${AP_NAME}" >/dev/null 2>&1 || true
-      nmcli device wifi rescan >/dev/null 2>&1 || true
-      sleep 5
-      new_state="$(nmcli -t -f STATE g 2>/dev/null || echo disconnected)"
-      if printf '%s' "${new_state}" | grep -qi '^connected'; then
-        log "Perfil cliente asumió la conectividad; ${AP_NAME} permanece desactivada"
-      else
-        log "No se consiguió conectividad tras conmutar; reactivando ${AP_NAME}"
-        nmcli connection up "${AP_NAME}" >/dev/null 2>&1 || true
+cleanup_runtime_duplicates() {
+  local target="$1"
+  local target_real=""
+  if [[ -n "${target}" && -e "${target}" ]]; then
+    target_real=$(readlink -f "${target}" 2>/dev/null || echo "")
+  fi
+  nmcli -t -f NAME,UUID,FILENAME con show 2>/dev/null | while IFS=: read -r name uuid filename; do
+    [[ "${name}" != "${AP_NAME}" ]] && continue
+    [[ -z "${uuid}" ]] && continue
+    if [[ -n "${target_real}" && -n "${filename}" ]]; then
+      local fname_real
+      fname_real=$(readlink -f "${filename}" 2>/dev/null || echo "")
+      if [[ -n "${fname_real}" && "${fname_real}" == "${target_real}" ]]; then
+        continue
       fi
-    else
-      log "Conectividad ${connectivity_lc:-unknown} con ${AP_NAME} activo pero sin perfiles cliente autoconnect=yes; sin cambios"
+    fi
+    nmcli con delete uuid "${uuid}" >/dev/null 2>&1 || true
+  done
+}
+
+ensure_ap_profile() {
+  local recreate=0
+  local existing_psk=""
+
+  if nmcli connection show "${AP_NAME}" >/dev/null 2>&1; then
+    existing_psk="$(nmcli -s -g wifi-sec.psk connection show "${AP_NAME}" 2>/dev/null || echo "")"
+    local iface mode method addr gateway dns autoconnect priority
+    iface="$(nmcli -g connection.interface-name connection show "${AP_NAME}" 2>/dev/null || echo "")"
+    mode="$(nmcli -g 802-11-wireless.mode connection show "${AP_NAME}" 2>/dev/null || echo "")"
+    method="$(nmcli -g ipv4.method connection show "${AP_NAME}" 2>/dev/null || echo "")"
+    addr="$(nmcli -g ipv4.addresses connection show "${AP_NAME}" 2>/dev/null | head -n1 || echo "")"
+    gateway="$(nmcli -g ipv4.gateway connection show "${AP_NAME}" 2>/dev/null || echo "")"
+    dns="$(nmcli -g ipv4.dns connection show "${AP_NAME}" 2>/dev/null || echo "")"
+    autoconnect="$(nmcli -g connection.autoconnect connection show "${AP_NAME}" 2>/dev/null || echo "")"
+    priority="$(nmcli -g connection.autoconnect-priority connection show "${AP_NAME}" 2>/dev/null || echo "")"
+    if [[ "${iface}" != "${AP_IFACE}" || "${mode}" != "ap" || "${method}" != "shared" || "${addr}" != "${AP_CIDR}" || "${gateway}" != "${AP_GATEWAY}" || -n "${dns}" || "${autoconnect}" != "no" || "${priority}" != "0" ]]; then
+      recreate=1
     fi
   else
-    log "Conectividad ${connectivity_lc:-unknown} con conexión activa en ${AP_IFACE}=${active_conn:-<ninguna>}; no se requiere AP"
+    recreate=1
+  fi
+
+  local effective_psk="${AP_PASS}"
+  [[ -z "${effective_psk}" ]] && effective_psk="${AP_PASS_DEFAULT}"
+  [[ -n "${existing_psk}" ]] && effective_psk="${existing_psk}"
+
+  if [[ "${recreate}" -eq 1 ]]; then
+    nmcli con delete "${AP_NAME}" >/dev/null 2>&1 || true
+    nmcli con add type wifi ifname "${AP_IFACE}" con-name "${AP_NAME}" ssid "${AP_SSID}" >/dev/null 2>&1 || {
+      log "No se pudo crear ${AP_NAME}"
+      return 1
+    }
+  fi
+
+  nmcli con modify "${AP_NAME}" connection.interface-name "${AP_IFACE}" >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" 802-11-wireless.mode ap 802-11-wireless.band bg >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" wifi-sec.key-mgmt wpa-psk >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" wifi-sec.psk "${effective_psk}" >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" ipv4.method shared >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" ipv4.addresses "${AP_CIDR}" >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" ipv4.gateway "${AP_GATEWAY}" >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" ipv4.never-default yes >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" -ipv4.dns >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" ipv6.method ignore >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" connection.autoconnect no >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" connection.autoconnect-priority 0 >/dev/null 2>&1 || true
+
+  install -d -m 0755 /etc/NetworkManager/system-connections
+  if nmcli con export "${AP_NAME}" "${AP_KEYFILE}" >/dev/null 2>&1; then
+    chmod 600 "${AP_KEYFILE}" >/dev/null 2>&1 || true
+    nmcli con load "${AP_KEYFILE}" >/dev/null 2>&1 || log "No se pudo recargar ${AP_NAME} desde ${AP_KEYFILE}"
+    cleanup_runtime_duplicates "${AP_KEYFILE}"
+  else
+    log "No se pudo exportar ${AP_NAME} a ${AP_KEYFILE}"
+  fi
+}
+
+attempt_client_profiles() {
+  local profiles=("$@")
+  [[ ${#profiles[@]} -eq 0 ]] && return 1
+
+  nmcli device wifi rescan >/dev/null 2>&1 || true
+  for profile in "${profiles[@]}"; do
+    [[ -z "${profile}" ]] && continue
+    log "Intentando activar perfil cliente '${profile}'"
+    nmcli con up "${profile}" >/dev/null 2>&1 || true
+    for _ in {1..5}; do
+      if has_connectivity; then
+        log "Conectividad recuperada mediante '${profile}'"
+        return 0
+      fi
+      sleep 3
+    done
+  done
+  return 1
+}
+
+rfkill unblock wifi 2>/dev/null || true
+nmcli radio wifi on >/dev/null 2>&1 || true
+
+state="$(nmcli -t -f STATE g 2>/dev/null || echo disconnected)"
+state_lc="${state,,}"
+
+device_info="$(nmcli -t -f DEVICE,TYPE,STATE,CONNECTION device status 2>/dev/null | awk -F: -v iface="${AP_IFACE}" '$1==iface {print $3":"$4; exit}')"
+wlan_state="${device_info%%:*}"
+wlan_connection="${device_info#*:}"
+[[ "${wlan_connection}" == "${device_info}" ]] && wlan_connection=""
+
+mapfile -t client_profiles < <(list_client_profiles)
+client_count=${#client_profiles[@]}
+
+if [[ "${state_lc}" == connected* ]]; then
+  if [[ "${wlan_connection}" == "${AP_NAME}" && ${client_count} -gt 0 ]]; then
+    log "Conectividad presente con ${AP_NAME} activo; intentando perfiles cliente"
+    nmcli con down "${AP_NAME}" >/dev/null 2>&1 || true
+    if attempt_client_profiles "${client_profiles[@]}"; then
+      exit 0
+    fi
+    log "No se consiguió cliente; reactivando ${AP_NAME}" 
+    nmcli con up "${AP_NAME}" >/dev/null 2>&1 || true
+  else
+    log "Conectividad presente (${state}); no se requiere AP"
   fi
   exit 0
 fi
 
 if [[ "${state_lc}" == connecting* ]]; then
-  log "NM=connecting → esperando hasta ${AP_ENSURE_CONNECTING_WAIT}s"
-  t_end=$(( $(date +%s) + AP_ENSURE_CONNECTING_WAIT ))
-  while [ "$(date +%s)" -lt "${t_end}" ]; do
-    connectivity_now="$(nmcli networking connectivity check 2>/dev/null | tr '[:upper:]' '[:lower:]' || echo unknown)"
-    if printf '%s' "${connectivity_now}" | grep -qiE '^(full|portal|limited|local)$'; then
-      log "Conectividad ${connectivity_now} conseguida durante espera → no AP"
+  log "NetworkManager en estado connecting; esperando hasta 45s"
+  end=$((SECONDS + 45))
+  while (( SECONDS < end )); do
+    if has_connectivity; then
+      log "Conectividad recuperada durante la espera"
       exit 0
     fi
-
     state_now="$(nmcli -t -f STATE g 2>/dev/null || echo disconnected)"
-    if printf '%s' "${state_now}" | grep -qi '^connected'; then
-      log "NM=connected tras espera → no AP"
+    state_now_lc="${state_now,,}"
+    if [[ "${state_now_lc}" == connected* ]]; then
+      log "NetworkManager pasó a ${state_now}; no se requiere AP"
       exit 0
     fi
-
-    if printf '%s' "${state_now}" | grep -qiE '^(disconnected|asleep|unknown)'; then
-      log "NM=${state_now} tras espera → proceder a AP"
-      break
-    fi
-
-    sleep "${AP_ENSURE_CONNECTING_STEP}"
+    sleep 3
   done
 fi
 
-connectivity_final="$(nmcli networking connectivity check 2>/dev/null | tr '[:upper:]' '[:lower:]' || echo unknown)"
-if printf '%s' "${connectivity_final}" | grep -qiE '^(full|portal|limited|local)$'; then
-  log "Conectividad ${connectivity_final} detectada → no AP"
+if has_connectivity; then
+  log "Conectividad detectada tras espera; no se sube AP"
   exit 0
 fi
 
-state_after_wait="$(nmcli -t -f STATE g 2>/dev/null || echo disconnected)"
-if printf '%s' "${state_after_wait}" | grep -qi '^connected'; then
-  log "NM=${state_after_wait}; conectividad presente → no AP"
-  exit 0
-fi
-
-connectivity="$(nmcli networking connectivity check 2>/dev/null || echo 'unknown')"
-case "${connectivity}" in
-  full|internet|portal|limited)
-    log "Conectividad (${connectivity}); bajando ${AP_NAME} si está activo"
-    if nmcli -t -f NAME con show --active 2>/dev/null | grep -qx "${AP_NAME}"; then
-      if nmcli connection down "${AP_NAME}" >/dev/null 2>&1; then
-        log "${AP_NAME} desactivada por conectividad existente"
-      fi
-    fi
+if [[ ${client_count} -gt 0 ]]; then
+  log "Sin conectividad; intentando perfiles cliente persistentes"
+  if nmcli -t -f NAME con show --active 2>/dev/null | grep -qx "${AP_NAME}"; then
+    nmcli con down "${AP_NAME}" >/dev/null 2>&1 || true
+  fi
+  if attempt_client_profiles "${client_profiles[@]}"; then
     exit 0
-    ;;
-esac
-
-log "Sin conectividad tras espera; preparando ${AP_NAME} en ${AP_IFACE}"
-rfkill unblock wifi 2>/dev/null || true
-nmcli radio wifi on >/dev/null 2>&1 || true
-
-ensure_profile() {
-  local recreate=0
-  if ! nmcli connection show "${AP_NAME}" >/dev/null 2>&1; then
-    recreate=1
-  else
-    local iface mode ipv4_method ipv4_addr ipv4_gw ipv4_dns key_mgmt
-    iface="$(nmcli -g connection.interface-name connection show "${AP_NAME}" 2>/dev/null || echo '')"
-    mode="$(nmcli -g 802-11-wireless.mode connection show "${AP_NAME}" 2>/dev/null || echo '')"
-    ipv4_method="$(nmcli -g ipv4.method connection show "${AP_NAME}" 2>/dev/null || echo '')"
-    ipv4_addr="$(nmcli -g ipv4.addresses connection show "${AP_NAME}" 2>/dev/null | head -n1 || echo '')"
-    ipv4_gw="$(nmcli -g ipv4.gateway connection show "${AP_NAME}" 2>/dev/null || echo '')"
-    ipv4_dns="$(nmcli -g ipv4.dns connection show "${AP_NAME}" 2>/dev/null || echo '')"
-    key_mgmt="$(nmcli -g wifi-sec.key-mgmt connection show "${AP_NAME}" 2>/dev/null || echo '')"
-    [[ "${iface}" != "${AP_IFACE}" ]] && recreate=1
-    [[ "${mode}" != "ap" ]] && recreate=1
-    [[ "${ipv4_method}" != "shared" ]] && recreate=1
-    [[ "${ipv4_addr}" != "${AP_CIDR}" ]] && recreate=1
-    [[ "${ipv4_gw}" != "${AP_GATEWAY}" ]] && recreate=1
-    [[ -n "${ipv4_dns}" ]] && recreate=1
-    [[ "${key_mgmt}" != "wpa-psk" ]] && recreate=1
   fi
+fi
 
-  local effective_psk="${AP_PASS}"
-  if [[ "${recreate}" -eq 0 ]]; then
-    local existing_psk
-    existing_psk="$(nmcli -s -g wifi-sec.psk connection show "${AP_NAME}" 2>/dev/null || echo '')"
-    [[ -n "${existing_psk}" ]] && effective_psk="${existing_psk}"
-    nmcli connection modify "${AP_NAME}" connection.interface-name "${AP_IFACE}" >/dev/null 2>&1 || true
-    nmcli connection modify "${AP_NAME}" 802-11-wireless.mode ap 802-11-wireless.band bg >/dev/null 2>&1 || true
-    nmcli connection modify "${AP_NAME}" ipv4.method shared ipv4.addresses "${AP_CIDR}" ipv4.gateway "${AP_GATEWAY}" >/dev/null 2>&1 || true
-    nmcli connection modify "${AP_NAME}" ipv4.never-default yes >/dev/null 2>&1 || true
-    nmcli connection modify "${AP_NAME}" -ipv4.dns >/dev/null 2>&1 || true
-    nmcli connection modify "${AP_NAME}" ipv6.method ignore >/dev/null 2>&1 || true
-    nmcli connection modify "${AP_NAME}" wifi-sec.key-mgmt wpa-psk >/dev/null 2>&1 || true
-    nmcli connection modify "${AP_NAME}" connection.autoconnect no connection.autoconnect-priority 100 >/dev/null 2>&1 || true
-    return 0
-  fi
-
-  log "Recreando perfil ${AP_NAME}"
-  local previous_psk
-  previous_psk="$(nmcli -s -g wifi-sec.psk connection show "${AP_NAME}" 2>/dev/null || echo '')"
-  [[ -n "${previous_psk}" ]] && effective_psk="${previous_psk}"
-
-  nmcli connection delete "${AP_NAME}" >/dev/null 2>&1 || true
-  nmcli con delete "BasculaAP" >/dev/null 2>&1 || true
-  sudo rm -f /etc/NetworkManager/system-connections/BasculaAP.nmconnection 2>/dev/null || true
-
-  if ! nmcli connection add type wifi ifname "${AP_IFACE}" con-name "${AP_NAME}" ssid "${AP_SSID}" >/dev/null 2>&1; then
-    log "Error al crear el perfil ${AP_NAME}"
-    nmcli dev status || true
-    nmcli -t -f NAME,TYPE,DEVICE con show || true
-    nmcli -g connection.interface-name,802-11-wireless.mode,ipv4.method,ipv4.addresses,ipv4.gateway,ipv4.dns con show "${AP_NAME}" || true
-    return 1
-  fi
-
-  nmcli connection modify "${AP_NAME}" connection.interface-name "${AP_IFACE}" 802-11-wireless.mode ap 802-11-wireless.band bg >/dev/null 2>&1 || return 1
-  nmcli connection modify "${AP_NAME}" ipv4.method shared ipv4.addresses "${AP_CIDR}" ipv4.gateway "${AP_GATEWAY}" ipv4.never-default yes >/dev/null 2>&1 || return 1
-  nmcli connection modify "${AP_NAME}" -ipv4.dns >/dev/null 2>&1 || true
-  nmcli connection modify "${AP_NAME}" ipv6.method ignore >/dev/null 2>&1 || true
-  nmcli connection modify "${AP_NAME}" wifi-sec.key-mgmt wpa-psk >/dev/null 2>&1 || return 1
-
-  [[ -z "${effective_psk}" ]] && effective_psk="${AP_PASS_DEFAULT}"
-  nmcli connection modify "${AP_NAME}" wifi-sec.psk "${effective_psk}" >/dev/null 2>&1 || return 1
-  nmcli connection modify "${AP_NAME}" connection.autoconnect no connection.autoconnect-priority 100 >/dev/null 2>&1 || return 1
-  return 0
-}
-
-if ! ensure_profile; then
+log "Sin conectividad válida; asegurando ${AP_NAME}"
+ensure_ap_profile || {
   log "No se pudo asegurar el perfil ${AP_NAME}"
   exit 1
-fi
+}
 
-if command -v systemctl >/dev/null 2>&1 && [[ -d /run/systemd/system ]]; then
+if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
   systemctl disable --now dnsmasq 2>/dev/null || true
-elif command -v service >/dev/null 2>&1; then
-  service dnsmasq stop >/dev/null 2>&1 || true
 fi
 
-if ! nmcli dev status 2>/dev/null | awk -v iface="${AP_IFACE}" 'NR>1 && $1 == iface {found=1} END {exit found?0:1}'; then
-  log "Interfaz ${AP_IFACE} no listada por nmcli; reintento posterior"
-  exit 75
-fi
-
-log "Activando ${AP_NAME}"
-if nmcli connection up "${AP_NAME}" ifname "${AP_IFACE}" >"${TMP_LOG}" 2>&1; then
-  while IFS= read -r line; do log "${line}"; done < "${TMP_LOG}" || true
-  sleep 1
-  log "${AP_NAME} activo en ${AP_IFACE} (${AP_CIDR})"
+if nmcli con up "${AP_NAME}" >/dev/null 2>&1; then
+  log "${AP_NAME} activada en ${AP_IFACE} (${AP_CIDR})"
   exit 0
 fi
 
-rc=$?
-log "Fallo al activar ${AP_NAME} (rc=${rc})"
-if [[ -s "${TMP_LOG}" ]]; then
-  while IFS= read -r line; do log "${line}"; done < "${TMP_LOG}" || true
-fi
-
-if grep -qiE 'No device|not find device|not available|device not managed' "${TMP_LOG}" 2>/dev/null; then
-  log "Interfaz ${AP_IFACE} no disponible; reintento posterior"
-  exit 75
-fi
-
-exit "${rc}"
+log "Fallo al activar ${AP_NAME}"
+exit 1

--- a/systemd/bascula-ap-ensure.service
+++ b/systemd/bascula-ap-ensure.service
@@ -2,14 +2,9 @@
 Description=Ensure Bascula AP when no other connectivity
 After=NetworkManager.service NetworkManager-wait-online.service
 Wants=network-online.target
-StartLimitIntervalSec=300
-StartLimitBurst=3
 
 [Service]
 Type=oneshot
-Environment=AP_ENSURE_CONNECTING_WAIT=45
-Environment=AP_ENSURE_CONNECTING_STEP=3
-# Ignore nm-online failure so the ensure script can still run
 ExecStartPre=-/usr/bin/nm-online -s -q -t 25
 ExecStart=/opt/bascula/current/scripts/bascula-ap-ensure.sh
 Restart=on-failure


### PR DESCRIPTION
## Summary
- persist the BasculaAP profile by recreating it with nmcli, exporting to /etc and cleaning runtime duplicates during install
- update the miniweb backend to create Wi-Fi client profiles in /etc with autoconnect priority 120, sanitized logging, and streamlined AP enable/disable endpoints
- rewrite bascula-ap-ensure to wait for connectivity, favour saved client profiles before raising the AP, and keep the AP profile consistent; adjust the systemd unit and docs accordingly

## Testing
- python -m compileall backend


------
https://chatgpt.com/codex/tasks/task_e_68e12d626b988326985773876932f2f1