### PR TITLE
Stabilize Bascula AP workflows

### DIFF
--- a/scripts/bascula-ap-ensure.sh
+++ b/scripts/bascula-ap-ensure.sh
@@ -10,29 +10,30 @@ log() {
   printf '[bascula-ap-ensure] %s\n' "$msg"
 }
 
-trap 'logger -t bascula-ap-ensure "error en línea $LINENO"; exit 1' ERR
+error_exit() {
+  local msg="$1"
+  logger -t bascula-ap-ensure -- "ERROR: $msg" 2>/dev/null || true
+  printf '[bascula-ap-ensure][err] %s\n' "$msg" >&2
+  exit 1
+}
 
 AP_NAME="${AP_NAME:-BasculaAP}"
 AP_SSID="${AP_SSID:-Bascula-AP}"
 AP_PASS_DEFAULT="Bascula1234"
 AP_PASS="${AP_PASS:-${AP_PASS_DEFAULT}}"
-AP_IFACE="wlan0"
+AP_IFACE="${AP_IFACE:-wlan0}"
 AP_GATEWAY="192.168.4.1"
 AP_CIDR="${AP_GATEWAY}/24"
-AP_KEYFILE="/etc/NetworkManager/system-connections/${AP_NAME}.nmconnection"
-
-nm-online -s -q -t 25 || true
+AP_PROFILE="/etc/NetworkManager/system-connections/${AP_NAME}.nmconnection"
 
 if ! command -v nmcli >/dev/null 2>&1; then
-  log "nmcli requerido pero no disponible; abortando"
-  exit 1
+  error_exit "nmcli requerido pero no disponible"
 fi
 
 has_connectivity() {
   local status
-  status=$(nmcli networking connectivity check 2>/dev/null || echo unknown)
-  status=${status,,}
-  case "${status}" in
+  status=$(nmcli networking connectivity check 2>/dev/null || echo "unknown")
+  case "${status,,}" in
     full|portal|limited|local)
       return 0
       ;;
@@ -41,133 +42,70 @@ has_connectivity() {
 }
 
 list_client_profiles() {
-  nmcli -t -f NAME,TYPE,802-11-wireless.mode,connection.autoconnect connection show 2>/dev/null |
-    awk -F: -v ap="${AP_NAME}" 'tolower($2)=="802-11-wireless" && tolower($3)=="infrastructure" && tolower($4)=="yes" && $1!=ap {print $1}'
-}
-
-cleanup_runtime_duplicates() {
-  local target="$1"
-  local target_real=""
-  if [[ -n "${target}" && -e "${target}" ]]; then
-    target_real=$(readlink -f "${target}" 2>/dev/null || echo "")
-  fi
-  nmcli -t -f NAME,UUID,FILENAME con show 2>/dev/null | while IFS=: read -r name uuid filename; do
-    [[ "${name}" != "${AP_NAME}" ]] && continue
-    [[ -z "${uuid}" ]] && continue
-    if [[ -n "${target_real}" && -n "${filename}" ]]; then
-      local fname_real
-      fname_real=$(readlink -f "${filename}" 2>/dev/null || echo "")
-      if [[ -n "${fname_real}" && "${fname_real}" == "${target_real}" ]]; then
-        continue
-      fi
-    fi
-    nmcli con delete uuid "${uuid}" >/dev/null 2>&1 || true
-  done
+  nmcli -t -f NAME,TYPE,802-11-wireless.mode connection show 2>/dev/null |
+    awk -F: -v ap="${AP_NAME}" 'tolower($2)=="802-11-wireless" && tolower($3)=="infrastructure" && $1!=ap {print $1}'
 }
 
 ensure_ap_profile() {
-  local recreate=0
-  local existing_psk=""
-
-  if nmcli connection show "${AP_NAME}" >/dev/null 2>&1; then
-    existing_psk="$(nmcli -s -g wifi-sec.psk connection show "${AP_NAME}" 2>/dev/null || echo "")"
-    local iface mode method addr gateway dns autoconnect priority
-    iface="$(nmcli -g connection.interface-name connection show "${AP_NAME}" 2>/dev/null || echo "")"
-    mode="$(nmcli -g 802-11-wireless.mode connection show "${AP_NAME}" 2>/dev/null || echo "")"
-    method="$(nmcli -g ipv4.method connection show "${AP_NAME}" 2>/dev/null || echo "")"
-    addr="$(nmcli -g ipv4.addresses connection show "${AP_NAME}" 2>/dev/null | head -n1 || echo "")"
-    gateway="$(nmcli -g ipv4.gateway connection show "${AP_NAME}" 2>/dev/null || echo "")"
-    dns="$(nmcli -g ipv4.dns connection show "${AP_NAME}" 2>/dev/null || echo "")"
-    autoconnect="$(nmcli -g connection.autoconnect connection show "${AP_NAME}" 2>/dev/null || echo "")"
-    priority="$(nmcli -g connection.autoconnect-priority connection show "${AP_NAME}" 2>/dev/null || echo "")"
-    if [[ "${iface}" != "${AP_IFACE}" || "${mode}" != "ap" || "${method}" != "shared" || "${addr}" != "${AP_CIDR}" || "${gateway}" != "${AP_GATEWAY}" || -n "${dns}" || "${autoconnect}" != "no" || "${priority}" != "0" ]]; then
-      recreate=1
-    fi
-  else
-    recreate=1
+  local effective_pass="${AP_PASS:-}" tmp_line
+  if [[ -z "${effective_pass}" ]]; then
+    effective_pass="${AP_PASS_DEFAULT}"
   fi
-
-  local effective_psk="${AP_PASS}"
-  [[ -z "${effective_psk}" ]] && effective_psk="${AP_PASS_DEFAULT}"
-  [[ -n "${existing_psk}" ]] && effective_psk="${existing_psk}"
-
-  if [[ "${recreate}" -eq 1 ]]; then
-    nmcli con delete "${AP_NAME}" >/dev/null 2>&1 || true
-    nmcli con add type wifi ifname "${AP_IFACE}" con-name "${AP_NAME}" ssid "${AP_SSID}" >/dev/null 2>&1 || {
-      log "No se pudo crear ${AP_NAME}"
-      return 1
-    }
-  fi
-
-  nmcli con modify "${AP_NAME}" connection.interface-name "${AP_IFACE}" >/dev/null 2>&1 || true
-  nmcli con modify "${AP_NAME}" 802-11-wireless.mode ap 802-11-wireless.band bg >/dev/null 2>&1 || true
-  nmcli con modify "${AP_NAME}" wifi-sec.key-mgmt wpa-psk >/dev/null 2>&1 || true
-  nmcli con modify "${AP_NAME}" wifi-sec.psk "${effective_psk}" >/dev/null 2>&1 || true
-  nmcli con modify "${AP_NAME}" ipv4.method shared >/dev/null 2>&1 || true
-  nmcli con modify "${AP_NAME}" ipv4.addresses "${AP_CIDR}" >/dev/null 2>&1 || true
-  nmcli con modify "${AP_NAME}" ipv4.gateway "${AP_GATEWAY}" >/dev/null 2>&1 || true
-  nmcli con modify "${AP_NAME}" ipv4.never-default yes >/dev/null 2>&1 || true
-  nmcli con modify "${AP_NAME}" -ipv4.dns >/dev/null 2>&1 || true
-  nmcli con modify "${AP_NAME}" ipv6.method ignore >/dev/null 2>&1 || true
-  nmcli con modify "${AP_NAME}" connection.autoconnect no >/dev/null 2>&1 || true
-  nmcli con modify "${AP_NAME}" connection.autoconnect-priority 0 >/dev/null 2>&1 || true
 
   install -d -m 0755 /etc/NetworkManager/system-connections
-  if nmcli con export "${AP_NAME}" "${AP_KEYFILE}" >/dev/null 2>&1; then
-    chmod 600 "${AP_KEYFILE}" >/dev/null 2>&1 || true
-    nmcli con load "${AP_KEYFILE}" >/dev/null 2>&1 || log "No se pudo recargar ${AP_NAME} desde ${AP_KEYFILE}"
-    cleanup_runtime_duplicates "${AP_KEYFILE}"
-  else
-    log "No se pudo exportar ${AP_NAME} a ${AP_KEYFILE}"
+
+  nmcli con down "${AP_NAME}" >/dev/null 2>&1 || true
+  nmcli con delete "${AP_NAME}" >/dev/null 2>&1 || true
+
+  if ! nmcli con add type wifi ifname "${AP_IFACE}" con-name "${AP_NAME}" ssid "${AP_SSID}" >/dev/null 2>&1; then
+    log "No se pudo crear el perfil ${AP_NAME}"
+    return 1
   fi
+
+  nmcli con modify "${AP_NAME}" 802-11-wireless.mode ap 802-11-wireless.band bg 802-11-wireless.channel 6 >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" wifi-sec.key-mgmt wpa-psk wifi-sec.proto rsn wifi-sec.pmf 1 wifi-sec.psk "${effective_pass}" >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" ipv4.method shared ipv4.addresses "${AP_CIDR}" ipv4.gateway "${AP_GATEWAY}" >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" -ipv4.dns >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" ipv4.never-default yes >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" connection.interface-name "${AP_IFACE}" connection.autoconnect no connection.autoconnect-priority 0 >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" ipv6.method ignore >/dev/null 2>&1 || true
+
+  if nmcli con export "${AP_NAME}" "${AP_PROFILE}" >/dev/null 2>&1; then
+    chmod 600 "${AP_PROFILE}" >/dev/null 2>&1 || true
+    nmcli con delete "${AP_NAME}" >/dev/null 2>&1 || true
+    if ! nmcli con load "${AP_PROFILE}" >/dev/null 2>&1; then
+      log "No se pudo recargar ${AP_NAME} desde ${AP_PROFILE}"
+    fi
+    while IFS=: read -r name uuid filename; do
+      [[ "${name}" != "${AP_NAME}" ]] && continue
+      [[ -z "${uuid}" ]] && continue
+      [[ "${filename}" == "${AP_PROFILE}" ]] && continue
+      nmcli con delete uuid "${uuid}" >/dev/null 2>&1 || true
+    done < <(nmcli -t -f NAME,UUID,FILENAME con show 2>/dev/null || true)
+  else
+    log "No se pudo exportar ${AP_NAME} a ${AP_PROFILE}"
+  fi
+
+  tmp_line=$(nmcli -t -f NAME,AUTOCONNECT,AUTOCONNECT-PRIORITY,FILENAME con show 2>/dev/null | grep "^${AP_NAME}:" || true)
+  [[ -n "${tmp_line}" ]] && log "Perfil ${AP_NAME} listo: ${tmp_line}"
+
+  return 0
 }
 
-attempt_client_profiles() {
-  local profiles=("$@")
-  [[ ${#profiles[@]} -eq 0 ]] && return 1
-
-  nmcli device wifi rescan >/dev/null 2>&1 || true
-  for profile in "${profiles[@]}"; do
+disable_client_autoconnect() {
+  local profile
+  while IFS= read -r profile; do
     [[ -z "${profile}" ]] && continue
-    log "Intentando activar perfil cliente '${profile}'"
-    nmcli con up "${profile}" >/dev/null 2>&1 || true
-    for _ in {1..5}; do
-      if has_connectivity; then
-        log "Conectividad recuperada mediante '${profile}'"
-        return 0
-      fi
-      sleep 3
-    done
-  done
-  return 1
+    nmcli con modify "${profile}" connection.autoconnect no connection.autoconnect-priority 0 >/dev/null 2>&1 || true
+    nmcli con down "${profile}" >/dev/null 2>&1 || true
+  done < <(list_client_profiles)
 }
 
-rfkill unblock wifi 2>/dev/null || true
-nmcli radio wifi on >/dev/null 2>&1 || true
-
-state="$(nmcli -t -f STATE g 2>/dev/null || echo disconnected)"
+state=$(nmcli -t -f STATE general status 2>/dev/null || echo "disconnected")
 state_lc="${state,,}"
 
-device_info="$(nmcli -t -f DEVICE,TYPE,STATE,CONNECTION device status 2>/dev/null | awk -F: -v iface="${AP_IFACE}" '$1==iface {print $3":"$4; exit}')"
-wlan_state="${device_info%%:*}"
-wlan_connection="${device_info#*:}"
-[[ "${wlan_connection}" == "${device_info}" ]] && wlan_connection=""
-
-mapfile -t client_profiles < <(list_client_profiles)
-client_count=${#client_profiles[@]}
-
 if [[ "${state_lc}" == connected* ]]; then
-  if [[ "${wlan_connection}" == "${AP_NAME}" && ${client_count} -gt 0 ]]; then
-    log "Conectividad presente con ${AP_NAME} activo; intentando perfiles cliente"
-    nmcli con down "${AP_NAME}" >/dev/null 2>&1 || true
-    if attempt_client_profiles "${client_profiles[@]}"; then
-      exit 0
-    fi
-    log "No se consiguió cliente; reactivando ${AP_NAME}" 
-    nmcli con up "${AP_NAME}" >/dev/null 2>&1 || true
-  else
-    log "Conectividad presente (${state}); no se requiere AP"
-  fi
+  log "Conectividad presente (${state}); no se activa AP"
   exit 0
 fi
 
@@ -176,13 +114,13 @@ if [[ "${state_lc}" == connecting* ]]; then
   end=$((SECONDS + 45))
   while (( SECONDS < end )); do
     if has_connectivity; then
-      log "Conectividad recuperada durante la espera"
+      log "Conectividad detectada durante la espera; no se activa AP"
       exit 0
     fi
-    state_now="$(nmcli -t -f STATE g 2>/dev/null || echo disconnected)"
-    state_now_lc="${state_now,,}"
-    if [[ "${state_now_lc}" == connected* ]]; then
-      log "NetworkManager pasó a ${state_now}; no se requiere AP"
+    state=$(nmcli -t -f STATE general status 2>/dev/null || echo "disconnected")
+    state_lc="${state,,}"
+    if [[ "${state_lc}" == connected* ]]; then
+      log "NetworkManager pasó a ${state}; no se activa AP"
       exit 0
     fi
     sleep 3
@@ -190,34 +128,22 @@ if [[ "${state_lc}" == connecting* ]]; then
 fi
 
 if has_connectivity; then
-  log "Conectividad detectada tras espera; no se sube AP"
+  log "Conectividad detectada; no se activa AP"
   exit 0
 fi
 
-if [[ ${client_count} -gt 0 ]]; then
-  log "Sin conectividad; intentando perfiles cliente persistentes"
-  if nmcli -t -f NAME con show --active 2>/dev/null | grep -qx "${AP_NAME}"; then
-    nmcli con down "${AP_NAME}" >/dev/null 2>&1 || true
-  fi
-  if attempt_client_profiles "${client_profiles[@]}"; then
-    exit 0
-  fi
+rfkill unblock wifi >/dev/null 2>&1 || true
+nmcli radio wifi on >/dev/null 2>&1 || true
+
+if ! ensure_ap_profile; then
+  error_exit "No se pudo asegurar el perfil ${AP_NAME}"
 fi
 
-log "Sin conectividad válida; asegurando ${AP_NAME}"
-ensure_ap_profile || {
-  log "No se pudo asegurar el perfil ${AP_NAME}"
-  exit 1
-}
-
-if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
-  systemctl disable --now dnsmasq 2>/dev/null || true
-fi
+disable_client_autoconnect
 
 if nmcli con up "${AP_NAME}" >/dev/null 2>&1; then
-  log "${AP_NAME} activada en ${AP_IFACE} (${AP_CIDR})"
+  log "${AP_NAME} activa en ${AP_IFACE} (${AP_CIDR})"
   exit 0
 fi
 
-log "Fallo al activar ${AP_NAME}"
-exit 1
+error_exit "Fallo al activar ${AP_NAME}"

--- a/system/os/bascula-ap-ensure.sh
+++ b/system/os/bascula-ap-ensure.sh
@@ -1,96 +1,156 @@
 #!/usr/bin/env bash
 #
 # bascula-ap-ensure.sh - Ensure BasculaAP comes up when no other connectivity exists
-#
+
 set -euo pipefail
 
 LOG_TAG="bascula-ap-ensure"
 LOG_FILE="/var/log/bascula/ap-ensure.log"
-TMP_OUTPUT="$(mktemp -t bascula-ap-ensure.XXXXXX 2>/dev/null || echo "/tmp/bascula-ap-ensure.$$")"
-trap 'rm -f "${TMP_OUTPUT}" 2>/dev/null || true' EXIT
 
 mkdir -p "$(dirname "${LOG_FILE}")" >/dev/null 2>&1 || true
 
-LOG() {
-  local msg="$*"
-  logger -t "${LOG_TAG}" -- "${msg}" 2>/dev/null || true
-  printf "[ap-ensure] %s\n" "${msg}"
-  printf '%s %s\n' "$(date --iso-8601=seconds 2>/dev/null || date)" "${msg}" >>"${LOG_FILE}" 2>/dev/null || true
+log() {
+  local msg="$1"
+  logger -t "${LOG_TAG}" -- "$msg" 2>/dev/null || true
+  printf '[ap-ensure] %s\n' "$msg"
+  printf '%s %s\n' "$(date --iso-8601=seconds 2>/dev/null || date)" "$msg" >>"${LOG_FILE}" 2>/dev/null || true
 }
 
-NMCLI_DIAG() {
-  LOG "Diagnóstico NetworkManager (${AP_IFACE}/${AP_NAME})"
-  if command -v nmcli >/dev/null 2>&1; then
-    while IFS= read -r line; do LOG "[diag] ${line}"; done < <(nmcli -f GENERAL,IP4,CONNECTION device show "${AP_IFACE}" 2>/dev/null || true)
-    while IFS= read -r line; do LOG "[diag] ${line}"; done < <(nmcli connection show "${AP_NAME}" 2>/dev/null || true)
-  fi
+error_exit() {
+  local msg="$1"
+  logger -t "${LOG_TAG}" -- "ERROR: $msg" 2>/dev/null || true
+  printf '[ap-ensure][err] %s\n' "$msg" >&2
+  printf '%s ERROR: %s\n' "$(date --iso-8601=seconds 2>/dev/null || date)" "$msg" >>"${LOG_FILE}" 2>/dev/null || true
+  exit 1
 }
 
 AP_NAME="${AP_NAME:-BasculaAP}"
+AP_SSID="${AP_SSID:-Bascula-AP}"
+AP_PASS_DEFAULT="Bascula1234"
+AP_PASS="${AP_PASS:-${AP_PASS_DEFAULT}}"
 AP_IFACE="${AP_IFACE:-wlan0}"
+AP_GATEWAY="192.168.4.1"
+AP_CIDR="${AP_GATEWAY}/24"
+AP_PROFILE="/etc/NetworkManager/system-connections/${AP_NAME}.nmconnection"
 
-HAS_CONNECTIVITY=0
-
-if command -v nmcli >/dev/null 2>&1; then
-  while IFS=: read -r DEVICE TYPE STATE; do
-    [[ -z "${DEVICE}" ]] && continue
-    [[ "${STATE}" != connected* ]] && continue
-
-    if [[ "${TYPE}" == "wifi" ]]; then
-      CONN_LINE=$(nmcli -t -f GENERAL.CONNECTION device show "${DEVICE}" 2>/dev/null || true)
-      CONN_NAME="${CONN_LINE#*:}"
-      [[ -z "${CONN_NAME}" ]] && continue
-      if [[ "${CONN_NAME}" == "${AP_NAME}" ]]; then
-        continue
-      fi
-      MODE=$(nmcli -t -f 802-11-wireless.mode connection show "${CONN_NAME}" 2>/dev/null || echo "")
-      if [[ "${MODE}" == "ap" ]]; then
-        continue
-      fi
-    fi
-
-    STATE_DETAIL=$(nmcli -t -f GENERAL.STATE device show "${DEVICE}" 2>/dev/null || true)
-    if [[ "${STATE_DETAIL}" == 100* ]]; then
-      HAS_CONNECTIVITY=1
-      LOG "${TYPE^} ${DEVICE} activo (${STATE_DETAIL}); no se requiere ${AP_NAME}"
-      break
-    fi
-  done < <(nmcli -t -f DEVICE,TYPE,STATE device status 2>/dev/null || true)
-else
-  # Fallback sin nmcli: revisar IPs directas
-  if ip -4 addr show | grep -E '^[0-9]+: (eth|wlan)' | grep -q 'inet '; then
-    HAS_CONNECTIVITY=1
-    LOG "Interfaces con IP detectadas sin nmcli; omitiendo ${AP_NAME}"
-  fi
+if ! command -v nmcli >/dev/null 2>&1; then
+  error_exit "nmcli requerido pero no disponible"
 fi
 
-if [[ "${HAS_CONNECTIVITY}" -eq 1 ]]; then
-  LOG "Conectividad presente; no se activa AP"
+has_connectivity() {
+  local status
+  status=$(nmcli networking connectivity check 2>/dev/null || echo "unknown")
+  case "${status,,}" in
+    full|portal|limited|local)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+list_client_profiles() {
+  nmcli -t -f NAME,TYPE,802-11-wireless.mode connection show 2>/dev/null |
+    awk -F: -v ap="${AP_NAME}" 'tolower($2)=="802-11-wireless" && tolower($3)=="infrastructure" && $1!=ap {print $1}'
+}
+
+ensure_ap_profile() {
+  local effective_pass="${AP_PASS:-}" info_line
+  if [[ -z "${effective_pass}" ]]; then
+    effective_pass="${AP_PASS_DEFAULT}"
+  fi
+
+  install -d -m 0755 /etc/NetworkManager/system-connections
+
+  nmcli con down "${AP_NAME}" >/dev/null 2>&1 || true
+  nmcli con delete "${AP_NAME}" >/dev/null 2>&1 || true
+
+  if ! nmcli con add type wifi ifname "${AP_IFACE}" con-name "${AP_NAME}" ssid "${AP_SSID}" >/dev/null 2>&1; then
+    log "No se pudo crear el perfil ${AP_NAME}"
+    return 1
+  fi
+
+  nmcli con modify "${AP_NAME}" 802-11-wireless.mode ap 802-11-wireless.band bg 802-11-wireless.channel 6 >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" wifi-sec.key-mgmt wpa-psk wifi-sec.proto rsn wifi-sec.pmf 1 wifi-sec.psk "${effective_pass}" >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" ipv4.method shared ipv4.addresses "${AP_CIDR}" ipv4.gateway "${AP_GATEWAY}" >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" -ipv4.dns >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" ipv4.never-default yes >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" connection.interface-name "${AP_IFACE}" connection.autoconnect no connection.autoconnect-priority 0 >/dev/null 2>&1 || true
+  nmcli con modify "${AP_NAME}" ipv6.method ignore >/dev/null 2>&1 || true
+
+  if nmcli con export "${AP_NAME}" "${AP_PROFILE}" >/dev/null 2>&1; then
+    chmod 600 "${AP_PROFILE}" >/dev/null 2>&1 || true
+    nmcli con delete "${AP_NAME}" >/dev/null 2>&1 || true
+    if ! nmcli con load "${AP_PROFILE}" >/dev/null 2>&1; then
+      log "No se pudo recargar ${AP_NAME} desde ${AP_PROFILE}"
+    fi
+    while IFS=: read -r name uuid filename; do
+      [[ "${name}" != "${AP_NAME}" ]] && continue
+      [[ -z "${uuid}" ]] && continue
+      [[ "${filename}" == "${AP_PROFILE}" ]] && continue
+      nmcli con delete uuid "${uuid}" >/dev/null 2>&1 || true
+    done < <(nmcli -t -f NAME,UUID,FILENAME con show 2>/dev/null || true)
+  else
+    log "No se pudo exportar ${AP_NAME} a ${AP_PROFILE}"
+  fi
+
+  info_line=$(nmcli -t -f NAME,AUTOCONNECT,AUTOCONNECT-PRIORITY,FILENAME con show 2>/dev/null | grep "^${AP_NAME}:" || true)
+  [[ -n "${info_line}" ]] && log "Perfil ${AP_NAME} listo: ${info_line}"
+
+  return 0
+}
+
+disable_client_autoconnect() {
+  local profile
+  while IFS= read -r profile; do
+    [[ -z "${profile}" ]] && continue
+    nmcli con modify "${profile}" connection.autoconnect no connection.autoconnect-priority 0 >/dev/null 2>&1 || true
+    nmcli con down "${profile}" >/dev/null 2>&1 || true
+  done < <(list_client_profiles)
+}
+
+state=$(nmcli -t -f STATE general status 2>/dev/null || echo "disconnected")
+state_lc="${state,,}"
+
+if [[ "${state_lc}" == connected* ]]; then
+  log "Conectividad presente (${state}); no se activa AP"
   exit 0
 fi
 
-LOG "Sin conectividad a Internet; activando ${AP_NAME}"
-if command -v nmcli >/dev/null 2>&1; then
-  if ! nmcli connection up "${AP_NAME}" >"${TMP_OUTPUT}" 2>&1; then
-    LOG "Fallo al activar ${AP_NAME}"
-    NMCLI_DIAG
-    if ! nmcli connection modify "${AP_NAME}" connection.autoconnect yes connection.autoconnect-priority 100 >/dev/null 2>&1; then
-      LOG "No se pudo forzar autoconnect como respaldo"
-    else
-      LOG "Autoconnect activado como respaldo para ${AP_NAME}"
+if [[ "${state_lc}" == connecting* ]]; then
+  log "NetworkManager en estado connecting; esperando hasta 45s"
+  end=$((SECONDS + 45))
+  while (( SECONDS < end )); do
+    if has_connectivity; then
+      log "Conectividad detectada durante la espera; no se activa AP"
+      exit 0
     fi
-    if [[ -s "${TMP_OUTPUT}" ]]; then
-      while IFS= read -r line; do LOG "[nmcli] ${line}"; done <"${TMP_OUTPUT}"
+    state=$(nmcli -t -f STATE general status 2>/dev/null || echo "disconnected")
+    state_lc="${state,,}"
+    if [[ "${state_lc}" == connected* ]]; then
+      log "NetworkManager pasó a ${state}; no se activa AP"
+      exit 0
     fi
-    exit 1
-  fi
-  if [[ -s "${TMP_OUTPUT}" ]]; then
-    while IFS= read -r line; do LOG "[nmcli] ${line}"; done <"${TMP_OUTPUT}"
-  fi
-else
-  LOG "nmcli no disponible; imposible activar ${AP_NAME}"
-  exit 1
+    sleep 3
+  done
 fi
 
-LOG "${AP_NAME} activado correctamente"
-exit 0
+if has_connectivity; then
+  log "Conectividad detectada; no se activa AP"
+  exit 0
+fi
+
+rfkill unblock wifi >/dev/null 2>&1 || true
+nmcli radio wifi on >/dev/null 2>&1 || true
+
+if ! ensure_ap_profile; then
+  error_exit "No se pudo asegurar el perfil ${AP_NAME}"
+fi
+
+disable_client_autoconnect
+
+if nmcli con up "${AP_NAME}" >/dev/null 2>&1; then
+  log "${AP_NAME} activa en ${AP_IFACE} (${AP_CIDR})"
+  exit 0
+fi
+
+error_exit "Fallo al activar ${AP_NAME}"


### PR DESCRIPTION
## Summary
- recreate the BasculaAP profile with deterministic nmcli commands and persist it under /etc while disabling any global dnsmasq unit
- harden the bascula-ap-ensure scripts to skip AP activation when connectivity exists, rebuild the profile, and drop client autoconnect before bringing the hotspot up
- extend the miniweb backend with reusable nmcli helpers, a new /api/network/connect endpoint, and safer enable-ap handling that stops client profiles before raising the AP

## Testing
- python -m compileall backend/miniweb.py

------
https://chatgpt.com/codex/tasks/task_e_68e13414cb34832691c6c7e5d3baf69a