### PR TITLE
Ensure AP persistence and respect force flag

### DIFF
--- a/backend/miniweb.py
+++ b/backend/miniweb.py
@@ -328,8 +328,8 @@ def _run_nmcli_command(
 
 
 async def _run_nmcli_async(
-    args: Sequence[str],
     *,
+    args: Sequence[str],
     check: bool = True,
     ok_codes: Set[int] | None = None,
     timeout: int = 30,
@@ -391,8 +391,7 @@ def _nmcli_get_first_value(args: List[str], timeout: int = 5) -> Optional[str]:
 
 async def _list_connection_entries(name: str) -> list[dict[str, str]]:
     try:
-        res = await _run_nmcli_async(
-            _nmcli_args(
+        res = await _run_nmcli_async(args=_nmcli_args(
                 "-t",
                 "--separator",
                 "|",
@@ -426,8 +425,7 @@ async def _list_connection_entries(name: str) -> list[dict[str, str]]:
 
 async def _get_active_connection_uuid(name: str) -> Optional[str]:
     try:
-        res = await _run_nmcli_async(
-            _nmcli_args(
+        res = await _run_nmcli_async(args=_nmcli_args(
                 "-t",
                 "--separator",
                 "|",
@@ -468,8 +466,7 @@ def _ip_is_ap_subnet(ip: str) -> bool:
 
 async def _cleanup_nmcli_duplicates(connection_id: str, persistent_path: Path | None) -> None:
     try:
-        res = await _run_nmcli_async(
-            _nmcli_args("-t", "-f", "NAME,UUID,FILENAME", "con", "show"),
+        res = await _run_nmcli_async(args=_nmcli_args("-t", "-f", "NAME,UUID,FILENAME", "con", "show"),
             check=False,
         )
     except FileNotFoundError as exc:
@@ -504,10 +501,47 @@ async def _cleanup_nmcli_duplicates(connection_id: str, persistent_path: Path | 
                     continue
             except Exception:
                 pass
-        await _run_nmcli_async(
-            _nmcli_args("con", "delete", "uuid", uuid),
+        await _run_nmcli_async(args=_nmcli_args("con", "delete", "uuid", uuid),
             check=False,
             ok_codes={0, 10},
+        )
+
+
+async def _ensure_connection_from_path(connection_id: str, persistent_path: Path) -> None:
+    try:
+        res = await _run_nmcli_async(args=_nmcli_args("-t", "-f", "NAME,FILENAME", "con", "show"),
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise PermissionError("NMCLI_NOT_AVAILABLE") from exc
+
+    resolved: Path | None
+    try:
+        resolved = persistent_path.resolve()
+    except Exception:
+        resolved = persistent_path
+
+    found = False
+    if res.returncode == 0:
+        for line in (res.stdout or "").strip().splitlines():
+            if not line:
+                continue
+            parts = line.split(":", 1)
+            if len(parts) != 2:
+                continue
+            name, filename = parts[0], parts[1]
+            if name != connection_id or not filename:
+                continue
+            try:
+                if Path(filename).resolve() == resolved:
+                    found = True
+                    break
+            except Exception:
+                continue
+
+    if not found:
+        await _run_nmcli_async(args=_nmcli_args("con", "load", str(persistent_path)),
+            check=False,
         )
 
 
@@ -519,8 +553,7 @@ class _ClientProfileState:
 
 
 async def _list_client_profiles_state() -> list[_ClientProfileState]:
-    cp = await _run_nmcli_async(
-        _nmcli_args(
+    cp = await _run_nmcli_async(args=_nmcli_args(
             "-t",
             "-f",
             "NAME,TYPE,AUTOCONNECT,AUTOCONNECT-PRIORITY",
@@ -548,8 +581,7 @@ async def _list_client_profiles_state() -> list[_ClientProfileState]:
 
 
 async def _down_active_wifi_clients() -> None:
-    cp = await _run_nmcli_async(
-        _nmcli_args(
+    cp = await _run_nmcli_async(args=_nmcli_args(
             "-t",
             "-f",
             "NAME,TYPE,DEVICE,STATE",
@@ -565,13 +597,11 @@ async def _down_active_wifi_clients() -> None:
             continue
         name, ctype, dev, _state = parts[0], parts[1], parts[2], parts[3]
         if ctype == "802-11-wireless" and dev == WIFI_INTERFACE and name != AP_CONNECTION_ID:
-            await _run_nmcli_async(
-                _nmcli_args("con", "down", name),
+            await _run_nmcli_async(args=_nmcli_args("con", "down", name),
                 check=False,
                 ok_codes={0, 10},
             )
-    await _run_nmcli_async(
-        _nmcli_args("dev", "disconnect", WIFI_INTERFACE),
+    await _run_nmcli_async(args=_nmcli_args("dev", "disconnect", WIFI_INTERFACE),
         check=False,
     )
 
@@ -585,8 +615,7 @@ async def _create_or_update_wifi_profile(
         raise RuntimeError("password_required")
 
     try:
-        await _run_nmcli_async(
-            _nmcli_args("con", "delete", ssid),
+        await _run_nmcli_async(args=_nmcli_args("con", "delete", ssid),
             check=False,
             ok_codes={0, 10},
         )
@@ -603,9 +632,8 @@ async def _create_or_update_wifi_profile(
             ssid,
             "ssid",
             ssid,
-            "ipv4.method",
-            "auto",
         ]
+
         if secured:
             add_args.extend(
                 ["wifi-sec.key-mgmt", "wpa-psk", "wifi-sec.psk", password or ""]
@@ -613,18 +641,17 @@ async def _create_or_update_wifi_profile(
         else:
             add_args.extend(["wifi-sec.key-mgmt", "none"])
 
-        await _run_nmcli_async(_nmcli_args(*add_args))
+        await _run_nmcli_async(args=_nmcli_args(*add_args))
 
-        if not secured:
-            await _run_nmcli_async(
-                _nmcli_args("con", "modify", ssid, "wifi-sec.psk", "")
+        await _run_nmcli_async(args=_nmcli_args(
+                "con",
+                "modify",
+                ssid,
+                "connection.autoconnect",
+                "yes",
             )
-
-        await _run_nmcli_async(
-            _nmcli_args("con", "modify", ssid, "connection.autoconnect", "yes")
         )
-        await _run_nmcli_async(
-            _nmcli_args(
+        await _run_nmcli_async(args=_nmcli_args(
                 "con",
                 "modify",
                 ssid,
@@ -632,58 +659,59 @@ async def _create_or_update_wifi_profile(
                 "200",
             )
         )
-        await _run_nmcli_async(
-            _nmcli_args("con", "modify", ssid, "connection.permissions", "")
+        await _run_nmcli_async(args=_nmcli_args(
+                "con",
+                "modify",
+                ssid,
+                "connection.permissions",
+                "",
+            )
         )
-        await _run_nmcli_async(
-            _nmcli_args(
-                "con", "modify", ssid, "connection.interface-name", WIFI_INTERFACE
+        await _run_nmcli_async(args=_nmcli_args(
+                "con",
+                "modify",
+                ssid,
+                "connection.interface-name",
+                WIFI_INTERFACE,
             )
         )
 
-        profile_path: Optional[Path] = None
-        res_filename = await _run_nmcli_async(
-            _nmcli_args(
-                "-g",
-                "connection.filename",
+        NM_CONNECTIONS_DIR.mkdir(parents=True, exist_ok=True)
+        safe_name = ssid.replace("/", "_").replace("\\", "_")
+        if not safe_name.strip():
+            safe_name = "wifi"
+        profile_path = NM_CONNECTIONS_DIR / f"{safe_name}.nmconnection"
+
+        await _run_nmcli_async(args=_nmcli_args(
                 "con",
-                "show",
+                "export",
                 ssid,
-            ),
+                str(profile_path),
+            )
+        )
+
+        await asyncio.to_thread(os.chmod, profile_path, 0o600)
+
+        await _run_nmcli_async(args=_nmcli_args("con", "load", str(profile_path)),
             check=False,
         )
-        if res_filename.returncode == 0:
-            for line in (res_filename.stdout or "").splitlines():
-                candidate = line.strip()
-                if candidate:
-                    profile_path = Path(candidate)
-                    break
 
-        if profile_path and profile_path.exists():
-            if not str(profile_path).startswith(str(NM_CONNECTIONS_DIR)):
-                NM_CONNECTIONS_DIR.mkdir(parents=True, exist_ok=True)
-                target_path = NM_CONNECTIONS_DIR / profile_path.name
-                await asyncio.to_thread(os.replace, profile_path, target_path)
-                profile_path = target_path
-                await _run_nmcli_async(
-                    _nmcli_args("con", "load", str(profile_path)),
-                    check=False,
-                )
-            await asyncio.to_thread(os.chmod, profile_path, 0o600)
-            await _cleanup_nmcli_duplicates(ssid, profile_path)
-            return profile_path
+        await _run_nmcli_async(args=_nmcli_args("con", "delete", ssid),
+            check=False,
+            ok_codes={0, 10},
+        )
 
-        NM_CONNECTIONS_DIR.mkdir(parents=True, exist_ok=True)
-        fallback = NM_CONNECTIONS_DIR / f"{ssid}.nmconnection"
-        return fallback
+        await _cleanup_nmcli_duplicates(ssid, profile_path)
+        await _ensure_connection_from_path(ssid, profile_path)
+
+        return profile_path
     except FileNotFoundError as exc:
         raise PermissionError("NMCLI_NOT_AVAILABLE") from exc
 
 
 async def _prepare_ap_for_wifi_connection() -> Optional[str]:
     try:
-        res = await _run_nmcli_async(
-            _nmcli_args(
+        res = await _run_nmcli_async(args=_nmcli_args(
                 "connection",
                 "modify",
                 AP_CONNECTION_ID,
@@ -728,8 +756,7 @@ async def _prepare_ap_for_wifi_connection() -> Optional[str]:
     for entry in entries:
         uuid = entry["uuid"]
         try:
-            res_mod = await _run_nmcli_async(
-                _nmcli_args(
+            res_mod = await _run_nmcli_async(args=_nmcli_args(
                     "connection",
                     "modify",
                     "uuid",
@@ -752,8 +779,7 @@ async def _prepare_ap_for_wifi_connection() -> Optional[str]:
     for entry in entries:
         uuid = entry["uuid"]
         try:
-            res_down = await _run_nmcli_async(
-                _nmcli_args("connection", "down", "uuid", uuid),
+            res_down = await _run_nmcli_async(args=_nmcli_args("connection", "down", "uuid", uuid),
                 timeout=10,
                 check=False,
                 ok_codes={0, 10},
@@ -770,8 +796,7 @@ async def _prepare_ap_for_wifi_connection() -> Optional[str]:
         if keep_uuid and uuid == keep_uuid:
             continue
         try:
-            res_del = await _run_nmcli_async(
-                _nmcli_args("connection", "delete", "uuid", uuid),
+            res_del = await _run_nmcli_async(args=_nmcli_args("connection", "delete", "uuid", uuid),
                 timeout=5,
                 check=False,
             )
@@ -802,8 +827,7 @@ async def _ensure_ap_autoconnect_disabled(keep_uuid: Optional[str]) -> None:
             "0",
         ]
         try:
-            res = await _run_nmcli_async(
-                _nmcli_args(*args),
+            res = await _run_nmcli_async(args=_nmcli_args(*args),
                 timeout=5,
                 check=False,
             )
@@ -831,8 +855,7 @@ async def _wait_for_wifi_activation(timeout_s: float = 45.0) -> tuple[bool, Opti
         LOG_NETWORK.info("Polling Wi-Fi activation (attempt %s)", attempt)
 
         try:
-            res_state = await _run_nmcli_async(
-                _nmcli_args("-g", "GENERAL.STATE", "device", "show", WIFI_INTERFACE),
+            res_state = await _run_nmcli_async(args=_nmcli_args("-g", "GENERAL.STATE", "device", "show", WIFI_INTERFACE),
                 timeout=5,
                 check=False,
             )
@@ -840,8 +863,7 @@ async def _wait_for_wifi_activation(timeout_s: float = 45.0) -> tuple[bool, Opti
             state_num_txt = state_txt.split(" ", 1)[0] if state_txt else ""
             state_code = int(state_num_txt) if state_num_txt.isdigit() else None
 
-            res_ip = await _run_nmcli_async(
-                _nmcli_args("-g", "IP4.ADDRESS", "device", "show", WIFI_INTERFACE),
+            res_ip = await _run_nmcli_async(args=_nmcli_args("-g", "IP4.ADDRESS", "device", "show", WIFI_INTERFACE),
                 timeout=5,
                 check=False,
             )
@@ -869,8 +891,7 @@ async def _reactivate_ap_after_failure() -> None:
         LOG_NETWORK.info(
             "Reactivating '%s' tras fallo y manteniendo autoconnect=no", AP_CONNECTION_ID
         )
-        await _run_nmcli_async(
-            _nmcli_args(
+        await _run_nmcli_async(args=_nmcli_args(
                 "connection",
                 "modify",
                 AP_CONNECTION_ID,
@@ -888,8 +909,7 @@ async def _reactivate_ap_after_failure() -> None:
 
     try:
         LOG_NETWORK.info("Bringing up '%s' after failure", AP_CONNECTION_ID)
-        await _run_nmcli_async(
-            _nmcli_args("connection", "up", AP_CONNECTION_ID),
+        await _run_nmcli_async(args=_nmcli_args("connection", "up", AP_CONNECTION_ID),
             timeout=20,
             check=False,
         )
@@ -1323,84 +1343,231 @@ def ensure_ap_profile() -> None:
             timeout=5,
             check=False,
         )
-        if existing.returncode == 0:
-            return
+        if existing.returncode != 0:
+            _run_nmcli_command(
+                _nmcli_args(
+                    "con",
+                    "add",
+                    "type",
+                    "wifi",
+                    "ifname",
+                    WIFI_INTERFACE,
+                    "con-name",
+                    AP_CONNECTION_ID,
+                    "autoconnect",
+                    "no",
+                    "ssid",
+                    AP_DEFAULT_SSID,
+                ),
+                timeout=10,
+                check=False,
+            )
     except FileNotFoundError:
         raise PermissionError("NMCLI_NOT_AVAILABLE")
 
-    create_res = _run_nmcli_command(
+    _run_nmcli_command(
         _nmcli_args(
             "con",
-            "add",
-            "type",
-            "wifi",
-            "ifname",
-            WIFI_INTERFACE,
-            "con-name",
+            "modify",
             AP_CONNECTION_ID,
-            "autoconnect",
-            "no",
-            "ssid",
+            "802-11-wireless.ssid",
             AP_DEFAULT_SSID,
         ),
-        timeout=10,
+        timeout=5,
         check=False,
     )
-    if create_res.returncode not in (0, 4):
-        message = (create_res.stderr or create_res.stdout).strip()
-        lower = message.lower()
-        if "already exists" not in lower and "exists" not in lower:
-            raise RuntimeError(message)
-
-    modify_res = _run_nmcli_command(
+    _run_nmcli_command(
         _nmcli_args(
             "con",
             "modify",
             AP_CONNECTION_ID,
             "connection.autoconnect",
             "no",
+        ),
+        timeout=5,
+        check=False,
+    )
+    _run_nmcli_command(
+        _nmcli_args(
+            "con",
+            "modify",
+            AP_CONNECTION_ID,
             "connection.autoconnect-priority",
             "0",
+        ),
+        timeout=5,
+        check=False,
+    )
+    _run_nmcli_command(
+        _nmcli_args(
+            "con",
+            "modify",
+            AP_CONNECTION_ID,
             "connection.interface-name",
             WIFI_INTERFACE,
+        ),
+        timeout=5,
+        check=False,
+    )
+    _run_nmcli_command(
+        _nmcli_args(
+            "con",
+            "modify",
+            AP_CONNECTION_ID,
             "802-11-wireless.mode",
             "ap",
+        ),
+        timeout=5,
+        check=False,
+    )
+    _run_nmcli_command(
+        _nmcli_args(
+            "con",
+            "modify",
+            AP_CONNECTION_ID,
             "802-11-wireless.band",
             "bg",
-            "ipv4.method",
-            "shared",
-            "ipv4.addresses",
-            "192.168.4.1/24",
-            "ipv6.method",
-            "ignore",
         ),
-        timeout=10,
+        timeout=5,
+        check=False,
     )
-    if modify_res.returncode != 0:
-        raise RuntimeError((modify_res.stderr or modify_res.stdout).strip())
+    _run_nmcli_command(
+        _nmcli_args(
+            "con",
+            "modify",
+            AP_CONNECTION_ID,
+            "802-11-wireless.channel",
+            "6",
+        ),
+        timeout=5,
+        check=False,
+    )
+    _run_nmcli_command(
+        _nmcli_args(
+            "con",
+            "modify",
+            AP_CONNECTION_ID,
+            "wifi-sec.key-mgmt",
+            "wpa-psk",
+        ),
+        timeout=5,
+        check=False,
+    )
+    _run_nmcli_command(
+        _nmcli_args(
+            "con",
+            "modify",
+            AP_CONNECTION_ID,
+            "wifi-sec.proto",
+            "rsn",
+        ),
+        timeout=5,
+        check=False,
+    )
 
-    if AP_DEFAULT_PASSWORD:
-        secret_ap_res = _run_nmcli_command(
+    pmf_res = _run_nmcli_command(
+        _nmcli_args(
+            "con",
+            "modify",
+            AP_CONNECTION_ID,
+            "wifi-sec.pmf",
+            "1",
+        ),
+        timeout=5,
+        check=False,
+    )
+    if pmf_res.returncode not in {0}:
+        _run_nmcli_command(
             _nmcli_args(
                 "con",
                 "modify",
                 AP_CONNECTION_ID,
-                "wifi-sec.key-mgmt",
-                "wpa-psk",
+                "802-11-wireless-security.pmf",
+                "1",
+            ),
+            timeout=5,
+            check=False,
+        )
+
+    if AP_DEFAULT_PASSWORD:
+        _run_nmcli_command(
+            _nmcli_args(
+                "con",
+                "modify",
+                AP_CONNECTION_ID,
                 "wifi-sec.psk",
                 AP_DEFAULT_PASSWORD,
             ),
             timeout=5,
+            check=False,
         )
-        if secret_ap_res.returncode != 0:
-            raise RuntimeError((secret_ap_res.stderr or secret_ap_res.stdout).strip())
-    else:
-        open_ap_res = _run_nmcli_command(
-            _nmcli_args("con", "modify", AP_CONNECTION_ID, "wifi-sec.key-mgmt", "none"),
-            timeout=5,
-        )
-        if open_ap_res.returncode != 0:
-            raise RuntimeError((open_ap_res.stderr or open_ap_res.stdout).strip())
+
+    _run_nmcli_command(
+        _nmcli_args(
+            "con",
+            "modify",
+            AP_CONNECTION_ID,
+            "ipv4.method",
+            "shared",
+        ),
+        timeout=5,
+        check=False,
+    )
+    _run_nmcli_command(
+        _nmcli_args(
+            "con",
+            "modify",
+            AP_CONNECTION_ID,
+            "ipv4.addresses",
+            "192.168.4.1/24",
+        ),
+        timeout=5,
+        check=False,
+    )
+    _run_nmcli_command(
+        _nmcli_args(
+            "con",
+            "modify",
+            AP_CONNECTION_ID,
+            "ipv4.gateway",
+            "192.168.4.1",
+        ),
+        timeout=5,
+        check=False,
+    )
+    _run_nmcli_command(
+        _nmcli_args(
+            "con",
+            "modify",
+            AP_CONNECTION_ID,
+            "ipv4.dns",
+            "",
+        ),
+        timeout=5,
+        check=False,
+    )
+    _run_nmcli_command(
+        _nmcli_args(
+            "con",
+            "modify",
+            AP_CONNECTION_ID,
+            "ipv4.never-default",
+            "yes",
+        ),
+        timeout=5,
+        check=False,
+    )
+    _run_nmcli_command(
+        _nmcli_args(
+            "con",
+            "modify",
+            AP_CONNECTION_ID,
+            "ipv6.method",
+            "ignore",
+        ),
+        timeout=5,
+        check=False,
+    )
 
 
 def _ethernet_connected() -> bool:
@@ -1866,31 +2033,32 @@ async def _handle_wifi_connect(credentials: WifiCredentials) -> Dict[str, Any]:
         _LAST_WIFI_CONNECT_REQUEST = None
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    ap_disabled = False
     success = False
 
+    flag_dir = Path("/run/bascula")
+    flag_path = flag_dir / "force_ap"
     try:
-        await _run_nmcli_async(
-            _nmcli_args("con", "modify", AP_CONNECTION_ID, "connection.autoconnect", "no"),
+        if flag_path.exists():
+            flag_path.unlink()
+    except Exception as exc:
+        LOG_NETWORK.debug("No se pudo eliminar flag force_ap: %s", exc)
+
+    try:
+        await _run_nmcli_async(args=_nmcli_args("con", "down", AP_CONNECTION_ID),
             check=False,
             ok_codes={0, 10},
         )
-
-        down_res = await _run_nmcli_async(
-            _nmcli_args("con", "down", AP_CONNECTION_ID),
+        await _run_nmcli_async(args=_nmcli_args("dev", "disconnect", WIFI_INTERFACE),
             check=False,
-            ok_codes={0, 10},
         )
-        if down_res.returncode in {0, 10}:
-            ap_disabled = True
-
-        await _run_nmcli_async(_nmcli_args("radio", "wifi", "on"), check=False)
+        await _run_nmcli_async(args=_nmcli_args("radio", "wifi", "on"),
+            check=False,
+        )
 
         LOG_NETWORK.info("Activating Wi-Fi connection '%s'", ssid)
-        await _run_nmcli_async(_nmcli_args("con", "up", ssid))
+        await _run_nmcli_async(args=_nmcli_args("con", "up", ssid))
 
-        state_check = await _run_nmcli_async(
-            _nmcli_args("-t", "-f", "STATE", "g"),
+        state_check = await _run_nmcli_async(args=_nmcli_args("-t", "-f", "STATE", "g"),
             check=False,
         )
         state_txt = (state_check.stdout or "").strip()
@@ -1901,12 +2069,9 @@ async def _handle_wifi_connect(credentials: WifiCredentials) -> Dict[str, Any]:
         if ok and ip_address:
             if _ip_is_ap_subnet(ip_address):
                 LOG_NETWORK.warning(
-                    "Wi-Fi '%s' obtained AP subnet IP %s; keeping AP disabled and reporting failure",
-                    ssid,
-                    ip_address,
+                    "Wi-Fi '%s' obtuvo IP %s en la subred del AP", ssid, ip_address
                 )
-                if ap_disabled:
-                    await _reactivate_ap_after_failure()
+                await _reactivate_ap_after_failure()
                 raise HTTPException(
                     status_code=502,
                     detail={
@@ -1917,11 +2082,6 @@ async def _handle_wifi_connect(credentials: WifiCredentials) -> Dict[str, Any]:
                 )
 
             LOG_NETWORK.info("Wi-Fi '%s' connected with IP %s", ssid, ip_address)
-            await _run_nmcli_async(
-                _nmcli_args("con", "down", AP_CONNECTION_ID),
-                check=False,
-                ok_codes={0, 10},
-            )
             try:
                 await _ensure_ap_autoconnect_disabled(None)
             except PermissionError as exc:
@@ -1947,14 +2107,12 @@ async def _handle_wifi_connect(credentials: WifiCredentials) -> Dict[str, Any]:
             }
 
         LOG_NETWORK.warning("Timed out waiting for Wi-Fi '%s' activation", ssid)
-        if ap_disabled:
-            await _reactivate_ap_after_failure()
+        await _reactivate_ap_after_failure()
         raise HTTPException(status_code=504, detail={"code": "WIFI_ACTIVATION_TIMEOUT", "ssid": ssid})
     except HTTPException:
         raise
     except PermissionError as exc:
-        if ap_disabled:
-            await _reactivate_ap_after_failure()
+        await _reactivate_ap_after_failure()
         code = str(exc)
         if code == "NMCLI_NOT_AVAILABLE":
             raise HTTPException(
@@ -1963,8 +2121,7 @@ async def _handle_wifi_connect(credentials: WifiCredentials) -> Dict[str, Any]:
             ) from exc
         raise HTTPException(status_code=400, detail={"code": code}) from exc
     except RuntimeError as exc:
-        if ap_disabled:
-            await _reactivate_ap_after_failure()
+        await _reactivate_ap_after_failure()
         message = str(exc)
         lower = message.lower()
         if "not authorized" in lower:
@@ -1989,8 +2146,7 @@ async def _handle_wifi_connect(credentials: WifiCredentials) -> Dict[str, Any]:
             (exc.output or "")[-500:],
             (exc.stderr or "")[-500:],
         )
-        if ap_disabled:
-            await _reactivate_ap_after_failure()
+        await _reactivate_ap_after_failure()
         raise HTTPException(
             status_code=400,
             detail={
@@ -1999,12 +2155,10 @@ async def _handle_wifi_connect(credentials: WifiCredentials) -> Dict[str, Any]:
             },
         ) from exc
     except FileNotFoundError as exc:
-        if ap_disabled:
-            await _reactivate_ap_after_failure()
+        await _reactivate_ap_after_failure()
         raise HTTPException(status_code=503, detail="nmcli no disponible") from exc
     except Exception as exc:
-        if ap_disabled:
-            await _reactivate_ap_after_failure()
+        await _reactivate_ap_after_failure()
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     finally:
         if not success:
@@ -2040,10 +2194,12 @@ async def miniweb_status():
 
 @app.post("/api/network/enable-ap")
 async def enable_ap():
+    flag_dir = Path("/run/bascula")
+    flag_dir.mkdir(parents=True, exist_ok=True)
     try:
-        prev = await _list_client_profiles_state()
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=503, detail="nmcli no disponible") from exc
+        (flag_dir / "force_ap").touch()
+    except Exception as exc:
+        LOG_NETWORK.debug("No se pudo crear flag force_ap: %s", exc)
 
     try:
         await asyncio.to_thread(ensure_ap_profile)
@@ -2057,113 +2213,39 @@ async def enable_ap():
     except FileNotFoundError as exc:
         raise HTTPException(status_code=503, detail="nmcli no disponible") from exc
 
-    await _run_nmcli_async(
-        _nmcli_args(
-            "con",
-            "modify",
-            AP_CONNECTION_ID,
-            "802-11-wireless.mode",
-            "ap",
-        ),
-        check=False,
-    )
-    await _run_nmcli_async(
-        _nmcli_args(
-            "con",
-            "modify",
-            AP_CONNECTION_ID,
-            "ipv4.method",
-            "shared",
-        ),
-        check=False,
-    )
-    await _run_nmcli_async(
-        _nmcli_args(
-            "con",
-            "modify",
-            AP_CONNECTION_ID,
-            "connection.interface-name",
-            WIFI_INTERFACE,
-        ),
-        check=False,
-    )
-    await _run_nmcli_async(
-        _nmcli_args(
-            "con",
-            "modify",
-            AP_CONNECTION_ID,
-            "connection.autoconnect",
-            "no",
-        ),
-        check=False,
-    )
-    await _run_nmcli_async(
-        _nmcli_args(
-            "con",
-            "modify",
-            AP_CONNECTION_ID,
-            "connection.autoconnect-priority",
-            "0",
-        ),
-        check=False,
-    )
-
     try:
-        await _run_nmcli_async(
-            _nmcli_args("con", "up", AP_CONNECTION_ID),
-            check=True,
-        )
-        return {"ok": True}
+        await _run_nmcli_async(args=_nmcli_args("con", "up", AP_CONNECTION_ID))
     except FileNotFoundError as exc:
         raise HTTPException(status_code=503, detail="nmcli no disponible") from exc
-    except subprocess.CalledProcessError as e:
-        for st in prev:
-            await _run_nmcli_async(
-                _nmcli_args(
-                    "con",
-                    "modify",
-                    st.name,
-                    "connection.autoconnect",
-                    st.autoconnect,
-                ),
-                check=False,
-            )
-            if st.priority.isdigit():
-                await _run_nmcli_async(
-                    _nmcli_args(
-                        "con",
-                        "modify",
-                        st.name,
-                        "connection.autoconnect-priority",
-                        st.priority,
-                    ),
-                    check=False,
-                )
-        try:
-            sorted_prev = sorted(
-                prev,
-                key=lambda s: ((s.autoconnect == "yes"), int(s.priority or "0")),
-                reverse=True,
-            )
-            for s in sorted_prev:
-                if s.autoconnect == "yes":
-                    rc = await _run_nmcli_async(
-                        _nmcli_args("con", "up", s.name),
-                        check=False,
-                    )
-                    if rc.returncode == 0:
-                        break
-        except Exception:
-            pass
-        detail = (e.stderr or e.output or str(e))[:500]
-        raise HTTPException(status_code=500, detail=f"Enable AP failed: {detail}")
+    except subprocess.CalledProcessError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=(exc.stderr or exc.output or str(exc))[:500],
+        ) from exc
+
+    try:
+        await asyncio.to_thread(
+            subprocess.run,
+            ["systemctl", "restart", "bascula-miniweb"],
+            check=False,
+        )
+    except Exception as exc:
+        LOG_NETWORK.debug("No se pudo reiniciar bascula-miniweb: %s", exc)
+
+    return {"ok": True}
 
 
 @app.post("/api/network/disable-ap")
 async def disable_ap():
+    flag_path = Path("/run/bascula/force_ap")
+    if flag_path.exists():
+        try:
+            flag_path.unlink()
+        except Exception as exc:
+            LOG_NETWORK.debug("No se pudo eliminar flag force_ap: %s", exc)
+
     try:
-        await _run_nmcli_async(
-            _nmcli_args("con", "down", AP_CONNECTION_ID),
+        await _run_nmcli_async(args=_nmcli_args("con", "down", AP_CONNECTION_ID),
             check=False,
             ok_codes={0, 10},
         )

--- a/scripts/bascula-ap-ensure.sh
+++ b/scripts/bascula-ap-ensure.sh
@@ -1,170 +1,210 @@
 #!/usr/bin/env bash
-#
-# Ensure the Bascula access point only comes up when there is no real connectivity
-# and at least one configured client profile is failing.
-
 set -euo pipefail
 
-log() {
-  local msg="$1"
-  logger -t bascula-ap-ensure -- "$msg" 2>/dev/null || true
-  printf '[bascula-ap-ensure] %s\n' "$msg"
-}
-
-error_exit() {
-  local msg="$1"
-  logger -t bascula-ap-ensure -- "ERROR: $msg" 2>/dev/null || true
-  printf '[bascula-ap-ensure][err] %s\n' "$msg" >&2
-  exit 1
-}
-
-AP_NAME="${AP_NAME:-BasculaAP}"
-AP_SSID="${AP_SSID:-Bascula-AP}"
-AP_PASS_DEFAULT="Bascula1234"
-AP_PASS="${AP_PASS:-${AP_PASS_DEFAULT}}"
-AP_IFACE="${AP_IFACE:-wlan0}"
+LOG_TAG="bascula-ap-ensure"
+LOG_FILE="/var/log/bascula-ap.log"
+AP_NAME="BasculaAP"
+AP_SSID="Bascula-AP"
+AP_PSK="Bascula1234"
+AP_IFACE="wlan0"
 AP_GATEWAY="192.168.4.1"
 AP_CIDR="${AP_GATEWAY}/24"
-AP_PROFILE_DIR="/etc/NetworkManager/system-connections"
+FORCE_FLAG="/run/bascula/force_ap"
+NMCLI_BIN="/usr/bin/nmcli"
 
-if ! command -v nmcli >/dev/null 2>&1; then
-  error_exit "nmcli requerido pero no disponible"
-fi
+log_dir="$(dirname "${LOG_FILE}")"
+install -d -m 0755 "${log_dir}" 2>/dev/null || true
+touch "${LOG_FILE}" 2>/dev/null || true
 
-real_connectivity() {
-  local status
-  status=$(nmcli networking connectivity check 2>/dev/null || echo "unknown")
-  case "${status,,}" in
-    full|portal)
+log_msg() {
+  local level="$1"
+  shift || true
+  local msg="$*"
+  local ts
+  ts="$(date '+%Y-%m-%d %H:%M:%S')"
+  logger -t "${LOG_TAG}" -p "user.${level}" -- "${msg}" 2>/dev/null || true
+  printf '%s [%s] %s\n' "${ts}" "${level^^}" "${msg}" >>"${LOG_FILE}" 2>/dev/null || true
+}
+
+log_info() { log_msg "info" "$*"; }
+log_warn() { log_msg "warn" "$*"; }
+log_error() { log_msg "err" "$*"; }
+
+redact_nmcli_args() {
+  local -a output=()
+  local skip_next=0
+  local arg
+  for arg in "$@"; do
+    if [[ ${skip_next} -eq 1 ]]; then
+      output+=("******")
+      skip_next=0
+      continue
+    fi
+    case "${arg}" in
+      wifi-sec.psk|802-11-wireless-security.psk|password|psk)
+        output+=("${arg}")
+        skip_next=1
+        continue
+        ;;
+      wifi-sec.psk=*|802-11-wireless-security.psk=*|password=*|psk=*)
+        output+=("${arg%%=*}=******")
+        continue
+        ;;
+    esac
+    output+=("${arg}")
+  done
+  if ((${#output[@]} == 0)); then
+    printf '%s' ""
+    return
+  fi
+  printf -v _nmcli_safe '%q ' "${output[@]}"
+  printf '%s' "${_nmcli_safe% }"
+}
+
+run_nmcli() {
+  local -a cmd=("${NMCLI_BIN}" "$@")
+  local safe
+  safe="$(redact_nmcli_args "${cmd[@]}")"
+  if ! "${cmd[@]}" >/dev/null 2>&1; then
+    local rc=$?
+    log_warn "nmcli fallo rc=${rc}: ${safe}"
+    return ${rc}
+  fi
+  log_info "nmcli ok: ${safe}"
+  return 0
+}
+
+nmcli_available() {
+  [[ -x "${NMCLI_BIN}" ]]
+}
+
+has_real_connectivity() {
+  if nmcli_available; then
+    local status
+    status="$(${NMCLI_BIN} -g CONNECTIVITY general status 2>/dev/null || true)"
+    if [[ "${status,,}" == "full" ]]; then
       return 0
-      ;;
-  esac
-
-  if ping -q -c 1 -W 3 1.1.1.1 >/dev/null 2>&1; then
-    return 0
+    fi
   fi
-
-  if getent ahostsv4 debian.org >/dev/null 2>&1; then
-    return 0
+  if ping -q -c1 -W3 8.8.8.8 >/dev/null 2>&1; then
+    if getent ahostsv4 google.com >/dev/null 2>&1; then
+      return 0
+    fi
   fi
-
   return 1
 }
 
-list_client_profiles() {
-  nmcli -t --separator '|' -f NAME,TYPE,802-11-wireless.mode,AUTOCONNECT connection show 2>/dev/null |
-    awk -F'|' -v ap="${AP_NAME}" 'tolower($2)=="802-11-wireless" && tolower($3)=="infrastructure" && $1!=ap {print $1 "|" $4}'
+ap_is_active() {
+  ${NMCLI_BIN} -t -f NAME connection show --active 2>/dev/null | grep -Fxq "${AP_NAME}"
 }
 
 ensure_ap_profile() {
-  install -d -m 0755 "${AP_PROFILE_DIR}"
+  if ! nmcli_available; then
+    log_error "nmcli no disponible"
+    return 1
+  fi
 
-  if ! nmcli -t -f NAME connection show "${AP_NAME}" >/dev/null 2>&1; then
-    nmcli connection add type wifi ifname "${AP_IFACE}" con-name "${AP_NAME}" ssid "${AP_SSID}" \
-      ipv4.method shared ipv4.addresses "${AP_CIDR}" ipv4.gateway "${AP_GATEWAY}" \
-      802-11-wireless.mode ap wifi-sec.key-mgmt wpa-psk wifi-sec.psk "${AP_PASS}" >/dev/null 2>&1 || \
-      error_exit "No se pudo crear el perfil ${AP_NAME}"
+  if ! ${NMCLI_BIN} -t -f NAME connection show "${AP_NAME}" >/dev/null 2>&1; then
+    log_info "Creando perfil AP ${AP_NAME}"
+    run_nmcli con add type wifi ifname "${AP_IFACE}" con-name "${AP_NAME}" ssid "${AP_SSID}" || true
   else
-    nmcli connection modify "${AP_NAME}" 802-11-wireless.mode ap \
-      wifi-sec.key-mgmt wpa-psk wifi-sec.psk "${AP_PASS}" >/dev/null 2>&1 || true
+    log_info "Perfil AP ${AP_NAME} encontrado, actualizando"
   fi
 
-  nmcli connection modify "${AP_NAME}" \
-    connection.autoconnect no \
-    connection.autoconnect-priority 0 \
-    connection.interface-name "${AP_IFACE}" \
-    802-11-wireless.band bg \
-    ipv4.method shared \
-    ipv4.addresses "${AP_CIDR}" \
-    ipv4.gateway "${AP_GATEWAY}" \
-    ipv4.never-default yes \
-    ipv6.method ignore >/dev/null 2>&1 || true
+  run_nmcli con modify "${AP_NAME}" 802-11-wireless.ssid "${AP_SSID}" || true
+  run_nmcli con modify "${AP_NAME}" 802-11-wireless.mode ap || true
+  run_nmcli con modify "${AP_NAME}" 802-11-wireless.band bg || true
+  run_nmcli con modify "${AP_NAME}" 802-11-wireless.channel 6 || true
+  run_nmcli con modify "${AP_NAME}" wifi-sec.key-mgmt wpa-psk || true
+  run_nmcli con modify "${AP_NAME}" wifi-sec.proto rsn || true
+  run_nmcli con modify "${AP_NAME}" wifi-sec.pmf 1 || run_nmcli con modify "${AP_NAME}" 802-11-wireless-security.pmf 1 || true
+  run_nmcli con modify "${AP_NAME}" wifi-sec.psk "${AP_PSK}" || true
+  run_nmcli con modify "${AP_NAME}" ipv4.method shared || true
+  run_nmcli con modify "${AP_NAME}" ipv4.addresses "${AP_CIDR}" || true
+  run_nmcli con modify "${AP_NAME}" ipv4.gateway "${AP_GATEWAY}" || true
+  run_nmcli con modify "${AP_NAME}" ipv4.dns "" || true
+  run_nmcli con modify "${AP_NAME}" ipv4.never-default yes || true
+  run_nmcli con modify "${AP_NAME}" connection.interface-name "${AP_IFACE}" || true
+  run_nmcli con modify "${AP_NAME}" connection.autoconnect no || true
+  run_nmcli con modify "${AP_NAME}" connection.autoconnect-priority 0 || true
+  run_nmcli con modify "${AP_NAME}" ipv6.method ignore || true
 }
 
-activate_client_profiles() {
-  local profile autocon
-  while IFS='|' read -r profile autocon; do
-    [[ -z "${profile}" ]] && continue
-    if real_connectivity; then
-      return 0
-    fi
-    if [[ "${autocon}" != "yes" ]]; then
-      continue
-    fi
-    log "Intentando activar perfil Wi-Fi '${profile}'"
-    nmcli connection up "${profile}" >/dev/null 2>&1 || true
-    sleep 5
-    if real_connectivity; then
-      return 0
-    fi
+disable_client_connections() {
+  local -a active
+  mapfile -t active < <(${NMCLI_BIN} -t -f NAME,DEVICE connection show --active 2>/dev/null || true)
+  local entry name device
+  for entry in "${active[@]}"; do
+    [[ -z "${entry}" ]] && continue
+    name="${entry%%:*}"
+    device="${entry##*:}"
+    [[ "${device}" != "${AP_IFACE}" ]] && continue
+    [[ "${name}" == "${AP_NAME}" ]] && continue
+    log_info "Desactivando conexión cliente ${name} en ${device}"
+    run_nmcli con down "${name}" || true
   done
-  return 1
+  log_info "Desconectando dispositivo ${AP_IFACE}"
+  run_nmcli dev disconnect "${AP_IFACE}" || true
 }
 
-count_failing_profiles() {
-  local profile autocon failures=0 total=0 active
-  mapfile -t active < <(nmcli -t --separator '|' -f NAME connection show --active 2>/dev/null || true)
-  while IFS='|' read -r profile autocon; do
-    [[ -z "${profile}" ]] && continue
-    [[ "${autocon}" != "yes" ]] && continue
-    (( total++ ))
-    local is_active=0
-    for entry in "${active[@]}"; do
-      [[ "${entry}" == "${profile}" ]] && { is_active=1; break; }
-    done
-    if (( is_active == 0 )); then
-      (( failures++ ))
+restart_miniweb() {
+  if command -v systemctl >/dev/null 2>&1; then
+    if systemctl restart bascula-miniweb >/dev/null 2>&1; then
+      log_info "Servicio bascula-miniweb reiniciado"
+    else
+      log_warn "No se pudo reiniciar bascula-miniweb"
     fi
-  done
-
-  if (( failures == 0 && total > 0 )); then
-    failures=${total}
+  else
+    log_warn "systemctl no disponible para reiniciar miniweb"
   fi
-
-  echo "${failures}"
 }
 
 main() {
-  nmcli radio wifi on >/dev/null 2>&1 || true
+  log_info "=== Ejecutando ensure AP ==="
 
-  if real_connectivity; then
-    log "Conectividad detectada; no se activa AP"
-    exit 0
+  iw reg set ES >/dev/null 2>&1 || log_warn "No se pudo fijar dominio regulatorio ES"
+  rfkill unblock wifi >/dev/null 2>&1 || log_warn "No se pudo desbloquear rfkill"
+  if nmcli_available; then
+    run_nmcli radio wifi on || true
+  else
+    log_error "nmcli no disponible; abortando"
+    return 1
   fi
 
-  mapfile -t client_profiles < <(list_client_profiles)
-
-  if (( ${#client_profiles[@]} == 0 )); then
-    log "Sin perfiles Wi-Fi cliente configurados; no se activa AP"
-    exit 0
+  local force_ap=0
+  if [[ -f "${FORCE_FLAG}" ]]; then
+    force_ap=1
+    log_info "Flag force_ap detectado; mantener AP forzado"
   fi
 
-  printf '%s\n' "${client_profiles[@]}" | activate_client_profiles || true
-
-  if real_connectivity; then
-    log "Conectividad restaurada tras reintentar perfiles cliente"
-    exit 0
+  if has_real_connectivity; then
+    log_info "Conectividad real detectada"
+    if (( force_ap )); then
+      log_info "force_ap activo: se preserva el AP"
+      return 0
+    fi
+    if ap_is_active; then
+      log_info "Desactivando AP por conectividad existente"
+      run_nmcli con down "${AP_NAME}" || true
+      run_nmcli dev disconnect "${AP_IFACE}" || true
+    else
+      log_info "AP ya inactivo"
+    fi
+    return 0
   fi
 
-  local failures
-  failures=$(printf '%s\n' "${client_profiles[@]}" | count_failing_profiles)
-
-  if [[ -z "${failures}" || "${failures}" == "0" ]]; then
-    log "No hay perfiles cliente fallando; no se activa AP"
-    exit 0
-  fi
-
+  log_info "Sin conectividad real; asegurando AP"
   ensure_ap_profile
+  disable_client_connections
 
-  nmcli device disconnect "${AP_IFACE}" >/dev/null 2>&1 || true
-  nmcli connection down "${AP_NAME}" >/dev/null 2>&1 || true
-
-  if nmcli connection up "${AP_NAME}" >/dev/null 2>&1; then
-    log "${AP_NAME} activo en ${AP_IFACE} (${AP_CIDR})"
-    exit 0
+  if run_nmcli con up "${AP_NAME}"; then
+    log_info "${AP_NAME} activo en ${AP_IFACE} (${AP_CIDR})"
+    restart_miniweb
+    return 0
   fi
 
-  error_exit "Fallo al activar ${AP_NAME}"
+  log_error "No se pudo activar ${AP_NAME}"
+  return 1
 }
 
 main "$@"

--- a/systemd/bascula-ap-ensure.service
+++ b/systemd/bascula-ap-ensure.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=Ensure Bascula AP when no other connectivity
-After=NetworkManager.service NetworkManager-wait-online.service
+After=NetworkManager.service network-online.target
 Wants=network-online.target
 
 [Service]
 Type=oneshot
+# No bloquear: si nm-online falla, continuar igualmente
 ExecStartPre=-/usr/bin/nm-online -s -q -t 25
 ExecStart=/opt/bascula/current/scripts/bascula-ap-ensure.sh
 Restart=on-failure


### PR DESCRIPTION
## Summary
- rewrite the bascula AP ensure service and script so it only brings up the hotspot when real connectivity is unavailable, honours /run/bascula/force_ap, and restarts miniweb after enabling the AP
- update backend nmcli helpers and network endpoints to create persistent Wi-Fi profiles in /etc, manage the force_ap flag, and avoid logging PSKs
- refresh the installer and README to export the AP profile via nmcli, set the regulatory domain, and document the new AP workflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e14c3166e48326b3ed1b9bce1133f5