### PR TITLE
Restore AP ensure timer

### DIFF
--- a/systemd/bascula-ap-ensure.service
+++ b/systemd/bascula-ap-ensure.service
@@ -1,12 +1,14 @@
 [Unit]
 Description=Ensure Bascula AP when no other connectivity
 After=NetworkManager.service NetworkManager-wait-online.service
-Wants=network-online.target
+Wants=NetworkManager-wait-online.service
 
 [Service]
 Type=oneshot
 ExecStartPre=-/usr/bin/nm-online -s -q -t 25
 ExecStart=/opt/bascula/current/scripts/bascula-ap-ensure.sh
+User=root
+Group=root
 Restart=on-failure
 RestartSec=5s
 

--- a/systemd/bascula-ap-ensure.timer
+++ b/systemd/bascula-ap-ensure.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Periodic Bascula AP ensure (retries)
+
+[Timer]
+OnBootSec=30
+OnUnitActiveSec=45
+AccuracySec=1s
+Unit=bascula-ap-ensure.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- add a systemd timer to rerun the bascula AP ensure unit periodically
- harden the bascula-ap-ensure service definition by setting the execution user/group and aligning dependencies
- extend the installer to deploy and enable the new timer alongside the service

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e164ad69cc83268c60cd3132f8c561