### PR TITLE
Improve Wi-Fi fallback and persist AP configuration

### DIFF
--- a/scripts/bascula-ap-ensure.sh
+++ b/scripts/bascula-ap-ensure.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #
-# Ensure the Bascula access point only comes up when there is no real connectivity
-# and at least one configured client profile is failing.
+# Ensure the Bascula access point is only active when connectivity is missing.
 
 set -euo pipefail
 
@@ -20,151 +19,120 @@ error_exit() {
 
 AP_NAME="${AP_NAME:-BasculaAP}"
 AP_SSID="${AP_SSID:-Bascula-AP}"
-AP_PASS_DEFAULT="Bascula1234"
-AP_PASS="${AP_PASS:-${AP_PASS_DEFAULT}}"
+AP_PASS="${AP_PASS:-Bascula1234}"
 AP_IFACE="${AP_IFACE:-wlan0}"
 AP_GATEWAY="192.168.4.1"
 AP_CIDR="${AP_GATEWAY}/24"
 AP_PROFILE_DIR="/etc/NetworkManager/system-connections"
+AP_PROFILE_PATH="${AP_PROFILE_DIR}/${AP_NAME}.nmconnection"
+FORCE_AP_FLAG="/run/bascula/force_ap"
+MINIWEB_SERVICE="bascula-miniweb"
 
-if ! command -v nmcli >/dev/null 2>&1; then
+NMCLI_BIN="${NMCLI_BIN:-$(command -v nmcli 2>/dev/null || true)}"
+if [[ -z "${NMCLI_BIN}" ]]; then
   error_exit "nmcli requerido pero no disponible"
 fi
-
-real_connectivity() {
-  local status
-  status=$(nmcli networking connectivity check 2>/dev/null || echo "unknown")
-  case "${status,,}" in
-    full|portal)
-      return 0
-      ;;
-  esac
-
-  if ping -q -c 1 -W 3 1.1.1.1 >/dev/null 2>&1; then
-    return 0
-  fi
-
-  if getent ahostsv4 debian.org >/dev/null 2>&1; then
-    return 0
-  fi
-
-  return 1
-}
-
-list_client_profiles() {
-  nmcli -t --separator '|' -f NAME,TYPE,802-11-wireless.mode,AUTOCONNECT connection show 2>/dev/null |
-    awk -F'|' -v ap="${AP_NAME}" 'tolower($2)=="802-11-wireless" && tolower($3)=="infrastructure" && $1!=ap {print $1 "|" $4}'
-}
 
 ensure_ap_profile() {
   install -d -m 0755 "${AP_PROFILE_DIR}"
 
-  if ! nmcli -t -f NAME connection show "${AP_NAME}" >/dev/null 2>&1; then
-    nmcli connection add type wifi ifname "${AP_IFACE}" con-name "${AP_NAME}" ssid "${AP_SSID}" \
-      ipv4.method shared ipv4.addresses "${AP_CIDR}" ipv4.gateway "${AP_GATEWAY}" \
-      802-11-wireless.mode ap wifi-sec.key-mgmt wpa-psk wifi-sec.psk "${AP_PASS}" >/dev/null 2>&1 || \
+  if ! "${NMCLI_BIN}" -t -f NAME connection show "${AP_NAME}" >/dev/null 2>&1; then
+    log "Creando perfil ${AP_NAME}"
+    "${NMCLI_BIN}" connection add \
+      type wifi \
+      ifname "${AP_IFACE}" \
+      con-name "${AP_NAME}" \
+      ssid "${AP_SSID}" >/dev/null 2>&1 || \
       error_exit "No se pudo crear el perfil ${AP_NAME}"
-  else
-    nmcli connection modify "${AP_NAME}" 802-11-wireless.mode ap \
-      wifi-sec.key-mgmt wpa-psk wifi-sec.psk "${AP_PASS}" >/dev/null 2>&1 || true
   fi
 
-  nmcli connection modify "${AP_NAME}" \
-    connection.autoconnect no \
-    connection.autoconnect-priority 0 \
-    connection.interface-name "${AP_IFACE}" \
+  "${NMCLI_BIN}" connection modify "${AP_NAME}" \
+    802-11-wireless.ssid "${AP_SSID}" \
+    802-11-wireless.mode ap \
     802-11-wireless.band bg \
+    802-11-wireless.channel 1 \
+    wifi-sec.key-mgmt wpa-psk \
+    wifi-sec.proto rsn \
+    wifi-sec.pmf 2 \
+    wifi-sec.psk "${AP_PASS}" \
     ipv4.method shared \
     ipv4.addresses "${AP_CIDR}" \
     ipv4.gateway "${AP_GATEWAY}" \
     ipv4.never-default yes \
-    ipv6.method ignore >/dev/null 2>&1 || true
+    connection.autoconnect no \
+    connection.autoconnect-priority 0 \
+    connection.interface-name "${AP_IFACE}" \
+    ipv6.method ignore >/dev/null 2>&1 || \
+    error_exit "No se pudo actualizar el perfil ${AP_NAME}"
+
+  local tmp_profile
+  tmp_profile=$(mktemp)
+  if "${NMCLI_BIN}" connection export "${AP_NAME}" "${tmp_profile}" >/dev/null 2>&1; then
+    install -D -m 0600 "${tmp_profile}" "${AP_PROFILE_PATH}"
+    "${NMCLI_BIN}" connection load "${AP_PROFILE_PATH}" >/dev/null 2>&1 || \
+      log "Advertencia: no se pudo recargar ${AP_PROFILE_PATH}"
+  else
+    log "Advertencia: no se pudo exportar el perfil ${AP_NAME}"
+  fi
+  rm -f "${tmp_profile}"
 }
 
-activate_client_profiles() {
-  local profile autocon
-  while IFS='|' read -r profile autocon; do
-    [[ -z "${profile}" ]] && continue
-    if real_connectivity; then
-      return 0
-    fi
-    if [[ "${autocon}" != "yes" ]]; then
-      continue
-    fi
-    log "Intentando activar perfil Wi-Fi '${profile}'"
-    nmcli connection up "${profile}" >/dev/null 2>&1 || true
-    sleep 5
-    if real_connectivity; then
-      return 0
-    fi
-  done
-  return 1
+ap_is_active() {
+  "${NMCLI_BIN}" -t -f NAME connection show --active 2>/dev/null | grep -Fxq "${AP_NAME}" || return 1
+  return 0
 }
 
-count_failing_profiles() {
-  local profile autocon failures=0 total=0 active
-  mapfile -t active < <(nmcli -t --separator '|' -f NAME connection show --active 2>/dev/null || true)
-  while IFS='|' read -r profile autocon; do
-    [[ -z "${profile}" ]] && continue
-    [[ "${autocon}" != "yes" ]] && continue
-    (( total++ ))
-    local is_active=0
-    for entry in "${active[@]}"; do
-      [[ "${entry}" == "${profile}" ]] && { is_active=1; break; }
-    done
-    if (( is_active == 0 )); then
-      (( failures++ ))
-    fi
-  done
+bring_down_ap() {
+  if ap_is_active; then
+    log "Desactivando ${AP_NAME} porque hay conectividad"
+    "${NMCLI_BIN}" connection down "${AP_NAME}" >/dev/null 2>&1 || true
+  fi
+}
 
-  if (( failures == 0 && total > 0 )); then
-    failures=${total}
+bring_up_ap() {
+  ensure_ap_profile
+
+  "${NMCLI_BIN}" radio wifi on >/dev/null 2>&1 || true
+  "${NMCLI_BIN}" device disconnect "${AP_IFACE}" >/dev/null 2>&1 || true
+  "${NMCLI_BIN}" connection down "${AP_NAME}" >/dev/null 2>&1 || true
+
+  if "${NMCLI_BIN}" connection up "${AP_NAME}" >/dev/null 2>&1; then
+    log "${AP_NAME} activo en ${AP_IFACE} (${AP_CIDR})"
+  else
+    error_exit "Fallo al activar ${AP_NAME}"
   fi
 
-  echo "${failures}"
+  if ! systemctl restart "${MINIWEB_SERVICE}" >/dev/null 2>&1; then
+    log "Advertencia: no se pudo reiniciar ${MINIWEB_SERVICE}"
+  fi
+}
+
+get_connectivity() {
+  local raw
+  raw=$("${NMCLI_BIN}" -g CONNECTIVITY general status 2>/dev/null || true)
+  if [[ -z "${raw}" ]]; then
+    echo "unknown"
+  else
+    printf '%s' "${raw}" | tr '[:upper:]' '[:lower:]'
+  fi
 }
 
 main() {
-  nmcli radio wifi on >/dev/null 2>&1 || true
+  local connectivity
+  connectivity=$(get_connectivity)
 
-  if real_connectivity; then
-    log "Conectividad detectada; no se activa AP"
+  if [[ "${connectivity}" == "full" && ! -f "${FORCE_AP_FLAG}" ]]; then
+    bring_down_ap
     exit 0
   fi
 
-  mapfile -t client_profiles < <(list_client_profiles)
-
-  if (( ${#client_profiles[@]} == 0 )); then
-    log "Sin perfiles Wi-Fi cliente configurados; no se activa AP"
-    exit 0
+  if [[ "${connectivity}" != "full" ]]; then
+    log "Conectividad=${connectivity:-desconocida}; asegurando ${AP_NAME}"
+  else
+    log "Flag de fuerza detectado; asegurando ${AP_NAME}"
   fi
 
-  printf '%s\n' "${client_profiles[@]}" | activate_client_profiles || true
-
-  if real_connectivity; then
-    log "Conectividad restaurada tras reintentar perfiles cliente"
-    exit 0
-  fi
-
-  local failures
-  failures=$(printf '%s\n' "${client_profiles[@]}" | count_failing_profiles)
-
-  if [[ -z "${failures}" || "${failures}" == "0" ]]; then
-    log "No hay perfiles cliente fallando; no se activa AP"
-    exit 0
-  fi
-
-  ensure_ap_profile
-
-  nmcli device disconnect "${AP_IFACE}" >/dev/null 2>&1 || true
-  nmcli connection down "${AP_NAME}" >/dev/null 2>&1 || true
-
-  if nmcli connection up "${AP_NAME}" >/dev/null 2>&1; then
-    log "${AP_NAME} activo en ${AP_IFACE} (${AP_CIDR})"
-    exit 0
-  fi
-
-  error_exit "Fallo al activar ${AP_NAME}"
+  bring_up_ap
 }
 
 main "$@"

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -1211,16 +1211,10 @@ if [[ "${HAS_SYSTEMD}" -eq 1 ]]; then
     warn "Servicio bascula-ap-ensure no instalado; omitiendo enable"
   fi
   if [[ "${AP_ENSURE_TIMER_INSTALLED}" -eq 1 ]]; then
-    if systemctl enable bascula-ap-ensure.timer; then
-      log "✓ Timer bascula-ap-ensure habilitado"
+    if systemctl enable --now bascula-ap-ensure.timer; then
+      log "✓ Timer bascula-ap-ensure habilitado e iniciado"
     else
-      warn "No se pudo habilitar bascula-ap-ensure.timer"
-      systemctl status bascula-ap-ensure.timer --no-pager || true
-    fi
-    if systemctl start bascula-ap-ensure.timer; then
-      log "✓ Timer bascula-ap-ensure iniciado"
-    else
-      warn "No se pudo iniciar bascula-ap-ensure.timer"
+      warn "No se pudo habilitar/iniciar bascula-ap-ensure.timer"
       systemctl status bascula-ap-ensure.timer --no-pager || true
     fi
   else

--- a/systemd/bascula-ap-ensure.service
+++ b/systemd/bascula-ap-ensure.service
@@ -1,14 +1,12 @@
 [Unit]
 Description=Ensure Bascula AP when no other connectivity
 After=NetworkManager.service NetworkManager-wait-online.service
-Wants=NetworkManager-wait-online.service
+Wants=network-online.target
 
 [Service]
 Type=oneshot
 ExecStartPre=-/usr/bin/nm-online -s -q -t 25
 ExecStart=/opt/bascula/current/scripts/bascula-ap-ensure.sh
-User=root
-Group=root
 Restart=on-failure
 RestartSec=5s
 

--- a/systemd/bascula-ap-ensure.timer
+++ b/systemd/bascula-ap-ensure.timer
@@ -3,8 +3,8 @@ Description=Periodic Bascula AP ensure (retries)
 
 [Timer]
 OnBootSec=30
-OnUnitActiveSec=45
-AccuracySec=1s
+OnUnitActiveSec=60
+AccuracySec=30
 Unit=bascula-ap-ensure.service
 Persistent=true
 


### PR DESCRIPTION
## Summary
- update the bascula AP ensure service/timer and deployment script so the watchdog runs periodically
- rebuild the ensure script to toggle the AP based on NetworkManager connectivity and export the AP profile
- persist Wi-Fi client profiles created via the miniweb by exporting them into NetworkManager's system-connections directory

## Testing
- python -m compileall backend/miniweb.py

------
https://chatgpt.com/codex/tasks/task_e_68e168b8da7c83268ce4a2c1968c02d0