### PR TITLE
Improve AP detection and service coordination

### DIFF
--- a/packaging/systemd/bascula-miniweb.service
+++ b/packaging/systemd/bascula-miniweb.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Bascula Mini-Web Backend
-After=network.target NetworkManager.service
+After=NetworkManager.service NetworkManager-wait-online.service bascula-ap-ensure.service
+Wants=NetworkManager-wait-online.service
 
 [Service]
 Type=simple
@@ -9,11 +10,10 @@ Group=pi
 WorkingDirectory=/opt/bascula/current
 Environment=PATH=/opt/bascula/current/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 Environment=BASCULA_CFG_DIR=/home/pi/.bascula
-# Permite consultar el PIN localmente y durante modo AP (la API decide). 0 para desactivar.
-Environment=BASCULA_ALLOW_PIN_READ=1
+ExecStartPre=-/usr/bin/nm-online -s -q -t 25
 ExecStart=/opt/bascula/current/.venv/bin/python -m uvicorn backend.miniweb:app --host 0.0.0.0 --port 8080
 Restart=always
-RestartSec=5
+RestartSec=2s
 
 [Install]
 WantedBy=multi-user.target

--- a/src/components/APModeScreen.tsx
+++ b/src/components/APModeScreen.tsx
@@ -70,7 +70,11 @@ export const APModeScreen = () => {
         const response = await fetch("/api/miniweb/status", { cache: "no-store" });
         if (response.ok) {
           const status = await response.json();
-          if (status?.connected === true && status?.ap_active === false) {
+          if (
+            status?.ap_active === false &&
+            typeof status?.connectivity === "string" &&
+            status.connectivity.toLowerCase() === "full"
+          ) {
             const ssid = typeof status.ssid === "string" && status.ssid ? status.ssid : "tu red WiFi";
             const ip =
               (typeof status.ip === "string" && status.ip) ||

--- a/src/pages/MiniWebConfig.tsx
+++ b/src/pages/MiniWebConfig.tsx
@@ -253,7 +253,11 @@ export const MiniWebConfig = () => {
               continue;
             }
             const status = await statusResponse.json();
-            if (status?.connected === true && status?.ap_active === false) {
+            if (
+              status?.ap_active === false &&
+              typeof status?.connectivity === "string" &&
+              status.connectivity.toLowerCase() === "full"
+            ) {
               const targetIp = status.ip || status.ip_address || window.location.hostname;
               const panelUrl = `http://${targetIp}:8080/`;
               setConnectionStatus({

--- a/systemd/bascula-miniweb.service
+++ b/systemd/bascula-miniweb.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Bascula Mini-Web Backend
-After=NetworkManager.service network-online.target
-Wants=network-online.target
+After=NetworkManager.service NetworkManager-wait-online.service bascula-ap-ensure.service
+Wants=NetworkManager-wait-online.service
 
 [Service]
 Type=simple
@@ -10,10 +10,10 @@ Group=pi
 WorkingDirectory=/opt/bascula/current
 Environment=PATH=/opt/bascula/current/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 Environment=BASCULA_CFG_DIR=/home/pi/.bascula
-# Environment=BASCULA_ALLOW_PIN_READ=1
+ExecStartPre=-/usr/bin/nm-online -s -q -t 25
 ExecStart=/opt/bascula/current/.venv/bin/python -m uvicorn backend.miniweb:app --host 0.0.0.0 --port 8080
 Restart=always
-RestartSec=5
+RestartSec=2s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- update bascula-miniweb systemd units to wait for NetworkManager, run nm-online before start, and restart quickly
- derive network status from nmcli in the backend, exposing connectivity/saved profile flags and improving AP enable rollback
- poll the new status fields in the UI to control AP mode messaging and show connection retries, and adjust install-all to enable both services together

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2083f94e88326929417f7455a3137