### PR TITLE
Fix miniweb assets and pin handling

### DIFF
--- a/src/components/APModeScreen.tsx
+++ b/src/components/APModeScreen.tsx
@@ -3,6 +3,12 @@ import { Wifi, QrCode, Settings, KeyRound, CheckCircle2, AlertCircle, Loader2 } 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 
+interface PinStatusResponse {
+  pin?: string;
+  pinRequired?: boolean;
+  message?: string;
+}
+
 export const APModeScreen = () => {
   const apSSID = "Bascula-AP";
   const apPassword = "Bascula1234";
@@ -21,25 +27,25 @@ export const APModeScreen = () => {
 
     const fetchPin = async () => {
       try {
-        const response = await fetch("/api/miniweb/pin");
+        const response = await fetch("/api/miniweb/pin", { cache: "no-store" });
+
+        if (!isMounted) return;
 
         if (response.ok) {
-          const data = await response.json();
-          if (!isMounted) return;
+          const data = (await response.json().catch(() => null)) as PinStatusResponse | null;
+          const pinValue = data && typeof data.pin === "string" ? data.pin : null;
+          const requiresPin = data?.pinRequired !== false;
 
-          if (data?.pin) {
-            setMiniWebPin(data.pin);
-            setPinMessage(null);
+          setMiniWebPin(pinValue);
+
+          if (requiresPin) {
+            setPinMessage(
+              data?.message ?? "El PIN se muestra directamente en la pantalla del dispositivo"
+            );
           } else {
-            setMiniWebPin(null);
-            setPinMessage("PIN no disponible en este momento");
+            setPinMessage(data?.message ?? "No se requiere PIN en esta red");
           }
-        } else if (response.status === 403) {
-          if (!isMounted) return;
-          setMiniWebPin(null);
-          setPinMessage("El PIN se muestra directamente en la pantalla del dispositivo");
         } else {
-          if (!isMounted) return;
           setMiniWebPin(null);
           setPinMessage("No se pudo obtener el PIN. Verifica la conexión.");
         }

--- a/src/pages/MiniWebConfig.tsx
+++ b/src/pages/MiniWebConfig.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Wifi, Lock, Save, RefreshCw, Check, AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -31,6 +31,12 @@ interface ApiErrorResponse {
   detail?: string | { code?: string; message?: string };
 }
 
+interface PinStatusResponse {
+  pin?: string;
+  pinRequired?: boolean;
+  message?: string;
+}
+
 export const MiniWebConfig = () => {
   const [networks, setNetworks] = useState<WifiNetwork[]>([]);
   const [selectedSSID, setSelectedSSID] = useState("");
@@ -50,64 +56,7 @@ export const MiniWebConfig = () => {
 
   const selectedNetwork = networks.find((network) => network.ssid === selectedSSID);
 
-  useEffect(() => {
-    const fetchPin = async () => {
-      try {
-        const response = await fetch('/api/miniweb/pin');
-        if (response.ok) {
-          const data = await response.json();
-          if (data?.pin) {
-            setDevicePin(data.pin);
-            setPinMessage(null);
-          }
-        } else if (response.status === 403) {
-          setDevicePin(null);
-          setPinMessage('El PIN se muestra en la pantalla del dispositivo');
-        } else {
-          setDevicePin(null);
-          setPinMessage('No se pudo obtener el PIN. Verifica la conexión.');
-        }
-      } catch (error) {
-        logger.error('Failed to fetch PIN', { error });
-        setDevicePin(null);
-        setPinMessage('No se pudo obtener el PIN. Verifica la conexión.');
-      }
-    };
-
-    fetchPin();
-  }, []);
-
-  // Check PIN for security
-  const checkPin = async (inputPin: string) => {
-    try {
-      const response = await fetch('/api/miniweb/verify-pin', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ pin: inputPin }),
-      });
-      
-      if (response.ok) {
-        setIsPinValid(true);
-        loadNetworks();
-      } else if (response.status === 429) {
-        toast({
-          title: 'Demasiados intentos',
-          description: 'Espera unos minutos antes de volver a intentar.',
-          variant: 'destructive',
-        });
-      } else {
-        toast({
-          title: "PIN incorrecto",
-          description: "Verifica el PIN en la pantalla del dispositivo",
-          variant: "destructive",
-        });
-      }
-    } catch (error) {
-      logger.error('Failed to verify PIN', { error });
-    }
-  };
-
-  const loadNetworks = async () => {
+  const loadNetworks = useCallback(async () => {
     setConnectionStatus({ type: 'idle', message: '' });
     setIsScanning(true);
     try {
@@ -129,11 +78,9 @@ export const MiniWebConfig = () => {
           mapped.sort((a, b) => b.signal - a.signal);
           setNetworks(mapped);
 
-          if (!selectedSSID) {
-            const active = mapped.find((net) => net.in_use);
-            if (active) {
-              setSelectedSSID(active.ssid);
-            }
+          const active = mapped.find((net) => net.in_use);
+          if (active) {
+            setSelectedSSID((current) => (current ? current : active.ssid));
           }
         } else {
           setNetworks([]);
@@ -177,7 +124,94 @@ export const MiniWebConfig = () => {
     } finally {
       setIsScanning(false);
     }
-  };
+  }, [toast]);
+
+  const checkPin = useCallback(
+    async (inputPin: string) => {
+      try {
+        const response = await fetch('/api/miniweb/verify-pin', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ pin: inputPin }),
+        });
+
+        if (response.ok) {
+          setIsPinValid(true);
+          await loadNetworks();
+        } else if (response.status === 429) {
+          toast({
+            title: 'Demasiados intentos',
+            description: 'Espera unos minutos antes de volver a intentar.',
+            variant: 'destructive',
+          });
+        } else {
+          toast({
+            title: 'PIN incorrecto',
+            description: 'Verifica el PIN en la pantalla del dispositivo',
+            variant: 'destructive',
+          });
+        }
+      } catch (error) {
+        logger.error('Failed to verify PIN', { error });
+      }
+    },
+    [loadNetworks, toast]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchPin = async () => {
+      try {
+        const response = await fetch('/api/miniweb/pin', { cache: 'no-store' });
+        if (cancelled) {
+          return;
+        }
+
+        if (response.ok) {
+          const data = (await response.json().catch(() => null)) as PinStatusResponse | null;
+          const pinValue = data && typeof data.pin === 'string' ? data.pin : null;
+          const requiresPin = data?.pinRequired !== false;
+
+          if (cancelled) {
+            return;
+          }
+
+          setDevicePin(pinValue);
+
+          if (requiresPin) {
+            setIsPinValid(false);
+            setPinMessage(
+              data?.message ?? 'Introduce el PIN que aparece en la pantalla del dispositivo.'
+            );
+          } else {
+            setIsPinValid(true);
+            setPinMessage(data?.message ?? 'No se requiere PIN en esta red.');
+            await loadNetworks();
+          }
+        } else {
+          setDevicePin(null);
+          setIsPinValid(false);
+          if (!cancelled) {
+            setPinMessage('No se pudo obtener el PIN. Verifica la conexión.');
+          }
+        }
+      } catch (error) {
+        logger.error('Failed to fetch PIN', { error });
+        if (!cancelled) {
+          setDevicePin(null);
+          setIsPinValid(false);
+          setPinMessage('No se pudo obtener el PIN. Verifica la conexión.');
+        }
+      }
+    };
+
+    void fetchPin();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loadNetworks]);
 
   const handleConnect = async () => {
     if (!selectedSSID) {


### PR DESCRIPTION
## Summary
- serve the SPA with immutable caching for hashed assets and explicit routes for manifest/icons from the public folder
- return structured JSON for /api/miniweb/pin so the UI no longer blanks on 403 responses and adapt the React screens accordingly
- verify dist/public artifacts during install, ensure readable permissions, and restart bascula-miniweb after deployment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2197941748326a5c54eccb4361828