### PR TITLE
Fix bootstrap error notification timing

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -147,8 +147,10 @@ async function bootstrap() {
     }
   }
 
-  notifyBootstrapError(lastError);
   renderApp();
+  window.setTimeout(() => {
+    notifyBootstrapError(lastError);
+  }, 0);
 }
 
 void bootstrap();


### PR DESCRIPTION
## Summary
- render the main application before sending the bootstrap error event
- defer the error notification dispatch to ensure listeners are registered

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2201957408326ba668aab7930422b