### PR TITLE
Add wait helper before launching the kiosk UI

### DIFF
--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -1261,6 +1261,11 @@ fi
 install -m 0644 "${SYSTEMD_SRC}" /etc/systemd/system/bascula-miniweb.service
 log "✓ Mini-web backend configurado"
 
+# --- Mini-Web wait helper ---
+log "Instalando helper wait-miniweb..."
+install -Dm755 "${PROJECT_ROOT}/scripts/wait-miniweb.sh" "${BASCULA_CURRENT_LINK}/scripts/wait-miniweb.sh"
+chown "${TARGET_USER}:${TARGET_GROUP}" "${BASCULA_CURRENT_LINK}/scripts/wait-miniweb.sh" || true
+
 # Install AP ensure service and script
 log "[17a/20] Configurando servicio de arranque de AP..."
 AP_ENSURE_SERVICE_INSTALLED=0
@@ -1416,6 +1421,7 @@ fi
 
 systemctl_safe daemon-reload
 systemctl_safe disable getty@tty1.service
+systemctl_safe enable bascula-miniweb.service
 systemctl_safe enable bascula-app.service
 log "✓ UI kiosk configurado"
 
@@ -1481,6 +1487,8 @@ log "Instalación finalizada"
 log "Backend de báscula predeterminado: UART (ESP32 en /dev/serial0)"
 log "Reiniciando bascula-miniweb para aplicar la última compilación"
 systemctl_safe restart bascula-miniweb.service
+log "Reiniciando bascula-app (UI kiosk) para aplicar la espera de Mini-Web"
+systemctl_safe restart bascula-app.service
 systemctl_safe status bascula-miniweb --no-pager -l
 if command -v ss >/dev/null 2>&1; then
   ss -ltnp | grep 8080 || true

--- a/scripts/wait-miniweb.sh
+++ b/scripts/wait-miniweb.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Espera a que Mini-Web responda antes de lanzar Chromium
+set -euo pipefail
+URL="${1:-http://127.0.0.1:8080/api/miniweb/status}"
+TIMEOUT="${2:-60}"
+
+echo "[wait-miniweb] Waiting up to ${TIMEOUT}s for ${URL} ..."
+for i in $(seq 1 "${TIMEOUT}"); do
+  if curl -fsS "${URL}" >/dev/null 2>&1; then
+    echo "[wait-miniweb] Mini-Web is up."
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "[wait-miniweb] Timeout after ${TIMEOUT}s" >&2
+# No fallamos duro: devolvemos 0 para no bloquear kiosco si el backend tarda más
+exit 0

--- a/systemd/bascula-ui.service
+++ b/systemd/bascula-ui.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Bascula Digital Pro - UI (Xorg kiosk)
-After=network-online.target
-Wants=network-online.target
+After=bascula-miniweb.service network-online.target
+Wants=bascula-miniweb.service network-online.target
 Conflicts=getty@tty1.service
 StartLimitIntervalSec=120
 StartLimitBurst=3
@@ -18,6 +18,8 @@ PermissionsStartOnly=yes
 ExecStartPre=/usr/bin/install -d -m 0755 -o pi -g pi /var/log/bascula
 ExecStartPre=/usr/bin/install -o pi -g pi -m 0644 /dev/null /var/log/bascula/app.log
 ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /home/pi/.local/share/xorg
+# Esperar a que Mini-Web responda antes de abrir Chromium
+ExecStartPre=/opt/bascula/current/scripts/wait-miniweb.sh http://127.0.0.1:8080/api/miniweb/status 60
 ExecStart=/bin/bash -lc 'STARTX_BIN="$(command -v startx || command -v xinit)"; if [ -z "$STARTX_BIN" ]; then echo "startx/xinit no disponible" >&2; exit 1; fi; if [ "$(basename "$STARTX_BIN")" = "startx" ]; then exec "$STARTX_BIN" -- :0 vt1; else exec "$STARTX_BIN" "$HOME/.xinitrc" -- :0 vt1; fi'
 Restart=on-failure
 RestartSec=2


### PR DESCRIPTION
## Summary
- add a wait-miniweb helper script that polls the local mini-web status endpoint
- have the kiosk systemd unit depend on mini-web and run the helper before starting Chromium
- install the helper during provisioning and ensure the kiosk and mini-web services are enabled and restarted

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e22b8dfdc8832693fdabb1f7b47b69