### PR TITLE
Ensure bascula-app waits for miniweb

### DIFF
--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Bascula Digital Pro - UI (Xorg kiosk)
+Requires=bascula-miniweb.service
+After=network-online.target
+After=bascula-miniweb.service
+Wants=network-online.target
+Conflicts=getty@tty1.service
+StartLimitIntervalSec=120
+StartLimitBurst=3
+
+[Service]
+Type=simple
+User=pi
+Group=pi
+WorkingDirectory=/home/pi/bascula-ui
+Environment=HOME=/home/pi
+Environment=USER=pi
+Environment=XDG_RUNTIME_DIR=/run/user/1000
+PermissionsStartOnly=yes
+ExecStartPre=/usr/bin/install -d -m 0755 -o pi -g pi /var/log/bascula
+ExecStartPre=/usr/bin/install -o pi -g pi -m 0644 /dev/null /var/log/bascula/app.log
+ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /home/pi/.local/share/xorg
+ExecStart=/bin/bash -lc 'STARTX_BIN="$(command -v startx || command -v xinit)"; if [ -z "$STARTX_BIN" ]; then echo "startx/xinit no disponible" >&2; exit 1; fi; if [ "$(basename "$STARTX_BIN")" = "startx" ]; then exec "$STARTX_BIN" -- :0 vt1; else exec "$STARTX_BIN" "$HOME/.xinitrc" -- :0 vt1; fi'
+Restart=on-failure
+RestartSec=2
+StandardOutput=journal
+StandardError=journal
+TTYPath=/dev/tty1
+TTYReset=yes
+TTYVHangup=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add bascula-miniweb.service as a requirement and startup dependency for bascula-app so the kiosk waits for the miniweb service

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2395da31483269d7bf87ec1b09915