### PR TITLE
Speed up kiosk UI boot without waiting for network

### DIFF
--- a/system/os/bascula-ap-ensure.service
+++ b/system/os/bascula-ap-ensure.service
@@ -1,12 +1,11 @@
 [Unit]
 Description=Ensure Bascula AP when no other connectivity
 After=NetworkManager.service
-After=NetworkManager-wait-online.service
-Wants=network-online.target
 
 [Service]
 Type=oneshot
-ExecStartPre=-/usr/bin/nm-online -s -q -t 25
+TimeoutStartSec=20
+ExecStartPre=-/usr/bin/nm-online -s -q -t 10
 ExecStart=/opt/bascula/current/scripts/bascula-ap-ensure.sh
 Restart=on-failure
 RestartSec=5s

--- a/systemd/bascula-ap-ensure.service
+++ b/systemd/bascula-ap-ensure.service
@@ -1,11 +1,11 @@
 [Unit]
 Description=Ensure Bascula AP when no saved Wi-Fi profiles
-After=NetworkManager.service NetworkManager-wait-online.service
-Wants=NetworkManager-wait-online.service
+After=NetworkManager.service
 
 [Service]
 Type=oneshot
-ExecStartPre=-/usr/bin/nm-online -s -q -t 25
+TimeoutStartSec=20
+ExecStartPre=-/usr/bin/nm-online -s -q -t 10
 ExecStart=/opt/bascula/current/scripts/bascula-ap-ensure.sh
 
 [Install]

--- a/systemd/bascula-ui.service
+++ b/systemd/bascula-ui.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Bascula Digital Pro - UI (Xorg kiosk)
-After=network-online.target
-Wants=network-online.target
+After=graphical.target systemd-user-sessions.service
 Conflicts=getty@tty1.service
 StartLimitIntervalSec=120
 StartLimitBurst=3


### PR DESCRIPTION
## Summary
- remove network-online.target dependency from the bascula UI service so it only waits for the graphical session
- install an idempotent override that caps NetworkManager-wait-online to 10 seconds during setup
- keep the AP ensure service non-blocking by shortening its wait and adding a startup timeout

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2568105bc8326af2d886636c5ec51