### PR TITLE
Ensure kiosk UI depends on miniweb service

### DIFF
--- a/systemd/bascula-ui.service
+++ b/systemd/bascula-ui.service
@@ -1,7 +1,10 @@
 [Unit]
 Description=Bascula Digital Pro - UI (Xorg kiosk)
-After=graphical.target systemd-user-sessions.service NetworkManager.service
+Requires=bascula-miniweb.service
+After=bascula-miniweb.service
 Wants=NetworkManager.service
+After=NetworkManager.service graphical.target systemd-user-sessions.service
+PartOf=bascula-miniweb.service
 Conflicts=getty@tty1.service
 StartLimitIntervalSec=120
 StartLimitBurst=3


### PR DESCRIPTION
## Summary
- restore the kiosk UI's hard dependency on bascula-miniweb
- keep NetworkManager ordering without waiting for network-online.target
- link the UI lifecycle to bascula-miniweb for coordinated restarts

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e25d354fd0832686f6a2890edd5ce8