### PR TITLE
Restore bascula AP ensure behavior to commit 255eec5

### DIFF
--- a/systemd/bascula-ap-ensure.service
+++ b/systemd/bascula-ap-ensure.service
@@ -1,11 +1,11 @@
 [Unit]
 Description=Ensure Bascula AP when no saved Wi-Fi profiles
-After=NetworkManager.service
-Wants=NetworkManager.service
+After=NetworkManager.service NetworkManager-wait-online.service
+Wants=NetworkManager-wait-online.service
 
 [Service]
 Type=oneshot
-TimeoutStartSec=8
+ExecStartPre=-/usr/bin/nm-online -s -q -t 25
 ExecStart=/opt/bascula/current/scripts/bascula-ap-ensure.sh
 
 [Install]


### PR DESCRIPTION
## Summary
- revert the bascula AP ensure script to the logic from commit 255eec5, reinstating saved-profile checks and hardened provisioning flow
- update the accompanying systemd unit to wait for NetworkManager online readiness before executing the script

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e26f33f0e48326bb421cf201f169e0