### PR TITLE
Improve kiosk robustness

### DIFF
--- a/.xinitrc
+++ b/.xinitrc
@@ -1,32 +1,15 @@
 #!/bin/sh
-# .xinitrc para Bascula UI - Chromium kiosk en Raspberry Pi
+# Minimal X session for Bascula kiosk
 
-# Deshabilitar screensaver y ahorro de energía
 xset s off
 xset -dpms
 xset s noblank
 
-# Ocultar cursor del mouse
 unclutter -idle 0.5 -root &
 
-# Iniciar openbox como window manager
 openbox &
 
-# Esperar a que el servidor X esté listo
 sleep 2
 
-# Lanzar Chromium en modo kiosk
-CHROME_BIN="$(command -v chromium 2>/dev/null || command -v chromium-browser 2>/dev/null || command -v ${CHROME_PKG:-chromium} 2>/dev/null || echo chromium)"
-exec "$CHROME_BIN" \
-  --kiosk \
-  --noerrdialogs \
-  --disable-infobars \
-  --no-first-run \
-  --enable-features=OverlayScrollbar \
-  --disable-translate \
-  --disable-features=TranslateUI \
-  --disk-cache-dir=/dev/null \
-  --overscroll-history-navigation=0 \
-  --disable-pinch \
-  --check-for-update-interval=31536000 \
-  http://localhost:8080
+chmod +x /opt/bascula/current/scripts/kiosk-launch.sh
+/opt/bascula/current/scripts/kiosk-launch.sh >> /var/log/bascula/app.log 2>&1

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -30,7 +30,12 @@ APT_PACKAGES=(
   v4l-utils
   python3-picamera2
   libcamera-apps
+  xserver-xorg
   xserver-xorg-legacy
+  xinit
+  x11-xserver-utils
+  openbox
+  unclutter
   python3-venv
   tesseract-ocr
   tesseract-ocr-spa
@@ -45,6 +50,16 @@ log "apt-get install -y ${APT_PACKAGES[*]}"
 if ! apt-get install -y "${APT_PACKAGES[@]}"; then
   warn "package installation failed"
 fi
+
+LOG_USER="pi"
+if ! id -u "${LOG_USER}" >/dev/null 2>&1; then
+  warn "user ${LOG_USER} not found; using ${TARGET_USER} for log ownership"
+  LOG_USER="${TARGET_USER}"
+fi
+
+log "ensuring kiosk log directory"
+install -d -m 0755 -o "${LOG_USER}" -g "${LOG_USER}" /var/log/bascula
+install -o "${LOG_USER}" -g "${LOG_USER}" -m 0644 /dev/null /var/log/bascula/app.log
 
 OCR_VENV_DIR="/opt/bascula/venv"
 OCR_CURRENT_DIR="/opt/bascula/current"

--- a/scripts/kiosk-launch.sh
+++ b/scripts/kiosk-launch.sh
@@ -1,90 +1,156 @@
 #!/usr/bin/env bash
-# Bascula UI - Chromium launcher with camera support
+# Robust Chromium kiosk launcher for Bascula UI
 
-set -euo pipefail
+set -Eeuo pipefail
+
+LOG_FILE="/var/log/bascula/app.log"
+LOG_DIR="$(dirname "${LOG_FILE}")"
+
+if [[ ! -d "${LOG_DIR}" ]]; then
+  mkdir -p "${LOG_DIR}" 2>/dev/null || true
+fi
+
+# Redirect all output to the log file while still allowing manual redirection in callers
+exec >>"${LOG_FILE}" 2>&1
 
 log() {
-  printf '[kiosk] %s\n' "$*"
+  printf '%(%Y-%m-%d %H:%M:%S)T [kiosk] %s\n' -1 "$*"
 }
 
 warn() {
-  printf '[kiosk][warn] %s\n' "$*" >&2
+  printf '%(%Y-%m-%d %H:%M:%S)T [kiosk][warn] %s\n' -1 "$*"
 }
 
 BASE_URL="${BASCULA_KIOSK_URL:-http://127.0.0.1:8080}"
 BASE_URL="${BASE_URL%/}"
+
+BASE_HOST_PORT="${BASE_URL#*://}"
+BASE_HOST_PORT="${BASE_HOST_PORT%%/*}"
+BASE_HOST="${BASE_HOST_PORT%%:*}"
+BASE_PORT="${BASE_HOST_PORT##*:}"
+if [[ -z "${BASE_HOST}" || "${BASE_HOST}" == "${BASE_HOST_PORT}" ]]; then
+  BASE_HOST="127.0.0.1"
+fi
+if [[ -z "${BASE_PORT}" || "${BASE_PORT}" == "${BASE_HOST}" ]]; then
+  BASE_PORT="8080"
+fi
+
 CONFIG_URL="${BASE_URL}/config"
 STATUS_URL="${BASE_URL}/api/miniweb/status"
-ASSET_URL="${BASE_URL}/icon-192.png"
 
-wait_for_endpoint() {
-  local url="$1"
-  local label="$2"
-  local attempts=200
-  local delay=1
+log "launcher starting (base URL: ${BASE_URL})"
 
-  for ((i = 1; i <= attempts; i++)); do
-    if curl -fsS --max-time 2 "$url" >/dev/null 2>&1; then
-      log "${label} ready after ${i} attempt(s)"
-      return 0
-    fi
-    sleep "${delay}"
-  done
+export DISPLAY="${DISPLAY:-:0}"
 
-  warn "${label} not ready after ${attempts} attempts"
+check_port() {
+  if exec 3<>"/dev/tcp/${BASE_HOST}/${BASE_PORT}"; then
+    exec 3>&- 3<&-
+    return 0
+  fi
+  return 1
+}
+
+check_status() {
+  local status_code
+  status_code="$(curl -sS -o /dev/null -w '%{http_code}' "${STATUS_URL}" || echo "000")"
+  if [[ "${status_code}" != "200" ]]; then
+    log "miniweb status not ready (http=${status_code})"
+    return 1
+  fi
   return 0
 }
 
-# Prepare X session preferences
-if command -v xset >/dev/null 2>&1; then
-  xset s off || true
-  xset -dpms || true
-  xset s noblank || true
+check_config() {
+  local html
+  if ! html="$(curl -fsS --max-time 5 "${CONFIG_URL}" 2>/dev/null)"; then
+    log "miniweb config endpoint not ready"
+    return 1
+  fi
+  local config_pattern='<script[^>]*src="/assets/index-[^"]+\.js"'
+  if [[ ${html} =~ ${config_pattern} ]]; then
+    return 0
+  fi
+  log "miniweb config missing assets bundle"
+  return 1
+}
+
+wait_for_miniweb() {
+  local attempt=0
+  local delay=1
+  local start_ts
+  start_ts="$(date +%s)"
+  while (( $(date +%s) - start_ts < 30 )); do
+    attempt=$((attempt + 1))
+    log "wait miniweb attempt ${attempt}" 
+    if ! check_port; then
+      log "miniweb port ${BASE_HOST}:${BASE_PORT} not available yet"
+    elif ! check_status; then
+      :
+    elif check_config; then
+      log "miniweb ready after ${attempt} attempt(s)"
+      return 0
+    fi
+    sleep "${delay}"
+    if (( delay < 5 )); then
+      delay=$((delay + 1))
+    fi
+  done
+  warn "miniweb not ready after 30s; continuing"
+  return 1
+}
+
+wait_for_miniweb
+
+CHROME_BIN="$(command -v chromium 2>/dev/null || command -v chromium-browser 2>/dev/null || echo chromium)"
+if ! command -v "${CHROME_BIN}" >/dev/null 2>&1; then
+  warn "Chromium binary not found (${CHROME_BIN}); attempting to continue"
 fi
-
-if command -v unclutter >/dev/null 2>&1; then
-  unclutter -idle 0.5 -root &
-fi
-
-# Ensure backend endpoints are reachable before launching the UI
-wait_for_endpoint "${CONFIG_URL}" "UI /config"
-wait_for_endpoint "${ASSET_URL}" "UI static asset"
-wait_for_endpoint "${STATUS_URL}" "Miniweb status API"
-
-DEFAULT_CHROMIUM="/usr/bin/chromium"
-CHROMIUM_BIN="$(command -v chromium 2>/dev/null || command -v chromium-browser 2>/dev/null || echo "${DEFAULT_CHROMIUM}")"
-APP_URL="${BASE_URL}/config?v=$(date +%s)"
-
-FLAGS=(
-  --kiosk
-  --noerrdialogs
-  --disable-infobars
-  --no-first-run
-  --no-default-browser-check
-  --autoplay-policy=no-user-gesture-required
-  --use-fake-ui-for-media-stream
-  --disable-translate
-  --disable-features=TranslateUI
-  --enable-features=OverlayScrollbar
-  --overscroll-history-navigation=0
-  --disable-pinch
-  --disk-cache-dir=/dev/null
-  --check-for-update-interval=31536000
-  --start-fullscreen
-  --window-position=0,0
-)
 
 LIBCAMERIFY_BIN="$(command -v libcamerify 2>/dev/null || true)"
-
 if [[ -n "${LIBCAMERIFY_BIN}" ]]; then
-  if [[ -x "${DEFAULT_CHROMIUM}" ]]; then
-    log "Launching Chromium through libcamerify (default binary)"
-    exec /usr/bin/libcamerify /usr/bin/chromium "${FLAGS[@]}" --app="${APP_URL}"
-  else
-    log "Launching Chromium through libcamerify (${CHROMIUM_BIN})"
-    exec /usr/bin/libcamerify "${CHROMIUM_BIN}" "${FLAGS[@]}" --app="${APP_URL}"
-  fi
-else
-  log "Launching Chromium directly"
-  exec "${CHROMIUM_BIN}" "${FLAGS[@]}" --app="${APP_URL}"
+  log "libcamerify detected: ${LIBCAMERIFY_BIN}"
 fi
+
+CHROMIUM_FLAGS=(
+  --kiosk
+  --noerrdialogs
+  --no-first-run
+  --disable-infobars
+  --autoplay-policy=no-user-gesture-required
+  --overscroll-history-navigation=0
+  --disable-pinch
+  --check-for-update-interval=31536000
+  --password-store=basic
+  --use-fake-ui-for-media-stream
+)
+
+BACKOFF_SEQUENCE=(2 4 8 15)
+backoff_index=0
+
+while true; do
+  APP_URL="${BASE_URL}/config?v=$(date +%s)"
+  log "launching Chromium -> ${APP_URL}"
+
+  start_run="$(date +%s)"
+  set +e
+  if [[ -n "${LIBCAMERIFY_BIN}" ]]; then
+    "${LIBCAMERIFY_BIN}" "${CHROME_BIN}" "${CHROMIUM_FLAGS[@]}" "${APP_URL}"
+  else
+    "${CHROME_BIN}" "${CHROMIUM_FLAGS[@]}" "${APP_URL}"
+  fi
+  rc=$?
+  set -e
+  end_run="$(date +%s)"
+
+  runtime=$((end_run - start_run))
+  if (( runtime > 60 )); then
+    backoff_index=0
+  elif (( backoff_index < ${#BACKOFF_SEQUENCE[@]} - 1 )); then
+    backoff_index=$((backoff_index + 1))
+  fi
+
+  delay="${BACKOFF_SEQUENCE[backoff_index]}"
+  log "Chromium exited rc=${rc}; re-launching in ${delay}s"
+  sleep "${delay}"
+
+done

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Bascula Digital Pro - Chromium kiosk
+Requires=bascula-miniweb.service
+After=bascula-miniweb.service
+Wants=network-online.target
+After=network-online.target
+Conflicts=getty@tty1.service
+StartLimitIntervalSec=0
+StartLimitBurst=0
+
+[Service]
+Type=simple
+User=pi
+Group=pi
+WorkingDirectory=/home/pi/bascula-ui
+Environment=HOME=/home/pi
+Environment=USER=pi
+Environment=XDG_RUNTIME_DIR=/run/user/1000
+PermissionsStartOnly=yes
+ExecStartPre=/usr/bin/install -d -m 0755 -o pi -g pi /var/log/bascula
+ExecStartPre=/usr/bin/install -o pi -g pi -m 0644 /dev/null /var/log/bascula/app.log
+ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /home/pi/.local/share/xorg
+ExecStart=/bin/bash -lc 'STARTX_BIN="$(command -v startx || command -v xinit)"; if [ -z "$STARTX_BIN" ]; then echo "startx/xinit no disponible" >&2; exit 1; fi; if [ "$(basename "$STARTX_BIN")" = "startx" ]; then exec "$STARTX_BIN" -- :0 vt1; else exec "$STARTX_BIN" "$HOME/.xinitrc" -- :0 vt1; fi'
+Restart=on-failure
+RestartSec=2
+StandardOutput=journal
+StandardError=journal
+TTYPath=/dev/tty1
+TTYReset=yes
+TTYVHangup=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- ensure kiosk X11 dependencies are installed and provision the shared log file during install
- replace the kiosk launcher with a resilient Chromium loop that waits for miniweb, logs to /var/log/bascula/app.log, and restarts with backoff
- streamline the X session startup and add the bascula-app systemd unit targeting the new launcher

## Testing
- bash -n scripts/kiosk-launch.sh

------
https://chatgpt.com/codex/tasks/task_e_68e29b18d1e883269ef3e5e0f1ddf066