### PR TITLE
Update backend and UI systemd units for new deployment layout

### DIFF
--- a/systemd/bascula-backend.service
+++ b/systemd/bascula-backend.service
@@ -5,16 +5,12 @@ After=network.target
 [Service]
 Type=simple
 User=pi
-WorkingDirectory=/home/pi/bascula-backend
-Environment="PATH=/home/pi/bascula-backend/venv/bin"
-ExecStart=/home/pi/bascula-backend/venv/bin/uvicorn main:app --host 0.0.0.0 --port 8080 --workers 2
+Group=pi
+WorkingDirectory=/opt/bascula/current
+Environment="PATH=/opt/bascula/current/.venv/bin:/usr/local/bin:/usr/bin:/bin"
+ExecStart=/opt/bascula/current/.venv/bin/uvicorn backend.main:app --host 0.0.0.0 --port 8081 --workers 2 --log-level info
 Restart=always
-RestartSec=5
-
-# Logging
-StandardOutput=journal
-StandardError=journal
-SyslogIdentifier=bascula-backend
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/bascula-ui.service
+++ b/systemd/bascula-ui.service
@@ -1,31 +1,26 @@
 [Unit]
 Description=Bascula Digital Pro - UI (Xorg kiosk)
-After=network-online.target
+After=network-online.target bascula-miniweb.service
 Wants=network-online.target
 Conflicts=getty@tty1.service
 StartLimitIntervalSec=120
 StartLimitBurst=3
 
 [Service]
-Type=simple
 User=pi
 Group=pi
-WorkingDirectory=/home/pi/bascula-ui
+WorkingDirectory=/opt/bascula/current
 Environment=HOME=/home/pi
-Environment=USER=pi
-Environment=XDG_RUNTIME_DIR=/run/user/1000
-PermissionsStartOnly=yes
-ExecStartPre=/usr/bin/install -d -m 0755 -o pi -g pi /var/log/bascula
-ExecStartPre=/usr/bin/install -o pi -g pi -m 0644 /dev/null /var/log/bascula/app.log
-ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /home/pi/.local/share/xorg
-ExecStart=/bin/bash -lc 'STARTX_BIN="$(command -v startx || command -v xinit)"; if [ -z "$STARTX_BIN" ]; then echo "startx/xinit no disponible" >&2; exit 1; fi; if [ "$(basename "$STARTX_BIN")" = "startx" ]; then exec "$STARTX_BIN" -- :0 vt1; else exec "$STARTX_BIN" "$HOME/.xinitrc" -- :0 vt1; fi'
-Restart=on-failure
-RestartSec=2
-StandardOutput=journal
-StandardError=journal
+PAMName=login
 TTYPath=/dev/tty1
 TTYReset=yes
 TTYVHangup=yes
+StandardInput=tty
+StandardOutput=journal
+StandardError=journal
+ExecStart=/usr/bin/startx -- -nocursor vt1
+Restart=always
+RestartSec=2
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- point the backend service to the /opt/bascula/current working tree and virtualenv
- update the UI unit to launch startx from the same deployment directory and coordinate with miniweb

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2a9734dac83269eddcae43abca985