### PR TITLE
Update systemd units for backend and UI

### DIFF
--- a/systemd/bascula-backend.service
+++ b/systemd/bascula-backend.service
@@ -1,16 +1,26 @@
 [Unit]
-Description=Bascula Backend - FastAPI Server
-After=network.target
+Description=Bascula Backend API (FastAPI)
+After=network-online.target bascula-miniweb.service
+Wants=network-online.target bascula-miniweb.service
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 [Service]
 Type=simple
 User=pi
 Group=pi
 WorkingDirectory=/opt/bascula/current
-Environment="PATH=/opt/bascula/current/.venv/bin:/usr/local/bin:/usr/bin:/bin"
-ExecStart=/opt/bascula/current/.venv/bin/uvicorn backend.main:app --host 0.0.0.0 --port 8081 --workers 2 --log-level info
+Environment=PATH=/opt/bascula/current/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=BASCULA_CFG_DIR=/home/pi/.bascula
+Environment=PYTHONUNBUFFERED=1
+Environment=UVICORN_WORKERS=2
+ExecStartPre=/usr/bin/install -d -m 0755 -o pi -g pi /var/log/bascula
+ExecStartPre=/usr/bin/install -o pi -g pi -m 0644 /dev/null /var/log/bascula/backend.log
+ExecStart=/opt/bascula/current/.venv/bin/python -m uvicorn backend.main:app --host 0.0.0.0 --port 8081 --workers ${UVICORN_WORKERS} --log-level info --proxy-headers --forwarded-allow-ips="*"
 Restart=always
-RestartSec=3
+RestartSec=5
+TimeoutStopSec=30
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/bascula-ui.service
+++ b/systemd/bascula-ui.service
@@ -1,24 +1,33 @@
 [Unit]
-Description=Bascula Digital Pro - UI (Xorg kiosk)
-After=network-online.target bascula-miniweb.service
-Wants=network-online.target
+Description=Bascula Digital Pro - UI (Chromium kiosk)
+After=systemd-user-sessions.service network-online.target bascula-miniweb.service
+Wants=network-online.target bascula-miniweb.service
+Requires=bascula-miniweb.service
 Conflicts=getty@tty1.service
 StartLimitIntervalSec=120
 StartLimitBurst=3
 
 [Service]
+Type=simple
 User=pi
 Group=pi
 WorkingDirectory=/opt/bascula/current
 Environment=HOME=/home/pi
-PAMName=login
+Environment=USER=pi
+Environment=DISPLAY=:0
+Environment=XDG_RUNTIME_DIR=/run/user/1000
 TTYPath=/dev/tty1
 TTYReset=yes
 TTYVHangup=yes
+TTYVTDisallocate=yes
 StandardInput=tty
 StandardOutput=journal
 StandardError=journal
-ExecStart=/usr/bin/startx -- -nocursor vt1
+PermissionsStartOnly=yes
+ExecStartPre=/usr/bin/chvt 1
+ExecStartPre=/usr/bin/install -d -m 0755 -o pi -g pi /var/log/bascula
+ExecStartPre=/usr/bin/install -o pi -g pi -m 0644 /dev/null /var/log/bascula/ui.log
+ExecStart=/usr/bin/startx /opt/bascula/current/.xinitrc -- :0 vt1 -nocursor
 Restart=always
 RestartSec=2
 


### PR DESCRIPTION
## Summary
- update the backend systemd unit with the new dependency ordering, environment configuration, and logging setup
- refresh the UI kiosk systemd unit to depend on the miniweb service and prepare the runtime environment before launching startx

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2adb4e5e4832680f63b4847dc0d00