### PR TITLE
Add Picamera2 locking and health endpoint

### DIFF
--- a/backend/camera.py
+++ b/backend/camera.py
@@ -1,13 +1,13 @@
 """Camera API exposing capture and MJPEG streaming via Picamera2."""
 from __future__ import annotations
 
-import asyncio
 import io
 import threading
-from typing import AsyncGenerator, Optional
+import time
+from typing import Optional
 
-from fastapi import APIRouter, HTTPException
-from fastapi.responses import Response, StreamingResponse
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from PIL import Image
 
 try:  # pragma: no cover - optional dependency in runtime
@@ -30,61 +30,64 @@ def _init_camera_if_needed() -> Optional["Picamera2"]:
     if Picamera2 is None:
         _CAMERA_ERROR = "picamera2_not_available"
         return None
-    try:
-        camera = Picamera2()
-        config = camera.create_preview_configuration(main={"size": (640, 480)})
-        camera.configure(config)
-        camera.start()
-        _CAMERA_INSTANCE = camera
-        _CAMERA_ERROR = None
-    except Exception as exc:  # pragma: no cover - hardware/runtime specific
-        _CAMERA_ERROR = f"camera_init_failed: {exc}"[:200]
-        _CAMERA_INSTANCE = None
+    with _CAMERA_LOCK:
+        if _CAMERA_INSTANCE is not None:
+            return _CAMERA_INSTANCE
+        try:
+            cam = Picamera2()
+            cfg = cam.create_preview_configuration(main={"size": (640, 480)})
+            cam.configure(cfg)
+            cam.start()
+            _CAMERA_INSTANCE = cam
+            _CAMERA_ERROR = None
+        except Exception as exc:  # pragma: no cover
+            _CAMERA_INSTANCE = None
+            _CAMERA_ERROR = f"camera_init_failed: {exc}"[:200]
     return _CAMERA_INSTANCE
 
 
-def _require_camera() -> "Picamera2":
-    camera = _init_camera_if_needed()
-    if camera is None:
-        raise HTTPException(status_code=503, detail=_CAMERA_ERROR or "camera_unavailable")
-    return camera
-
-
-def _capture_jpeg_bytes(camera: "Picamera2") -> bytes:
-    with _CAMERA_LOCK:
-        frame = camera.capture_array()
-    image = Image.fromarray(frame)
-    buffer = io.BytesIO()
-    image.save(buffer, format="JPEG", quality=85)
-    return buffer.getvalue()
+@router.get("/health")
+def camera_health():
+    cam = _init_camera_if_needed()
+    return {"ok": cam is not None, "reason": _CAMERA_ERROR}
 
 
 @router.get("/capture")
-async def capture_photo() -> Response:
-    camera = _require_camera()
-    jpeg_bytes = await asyncio.to_thread(_capture_jpeg_bytes, camera)
-    return Response(content=jpeg_bytes, media_type="image/jpeg")
-
-
-async def _mjpeg_generator(camera: "Picamera2") -> AsyncGenerator[bytes, None]:
-    boundary = b"--frame"
-    while True:
-        frame_bytes = await asyncio.to_thread(_capture_jpeg_bytes, camera)
-        payload = (
-            boundary
-            + b"\r\nContent-Type: image/jpeg\r\nContent-Length: "
-            + str(len(frame_bytes)).encode()
-            + b"\r\n\r\n"
-            + frame_bytes
-            + b"\r\n"
+def capture_jpeg():
+    cam = _init_camera_if_needed()
+    if cam is None:
+        return JSONResponse(
+            {"ok": False, "reason": _CAMERA_ERROR or "camera_unavailable"},
+            status_code=503,
         )
-        yield payload
-        await asyncio.sleep(1 / 12)
+    try:
+        arr = cam.capture_array()
+        buf = io.BytesIO()
+        Image.fromarray(arr).save(buf, format="JPEG", quality=85)
+        return Response(content=buf.getvalue(), media_type="image/jpeg")
+    except Exception as exc:
+        return JSONResponse(
+            {"ok": False, "reason": f"capture_failed: {exc}"[:200]},
+            status_code=503,
+        )
 
 
 @router.get("/stream")
-async def stream_mjpeg() -> StreamingResponse:
-    camera = _require_camera()
-    generator = _mjpeg_generator(camera)
-    media_type = "multipart/x-mixed-replace; boundary=frame"
-    return StreamingResponse(generator, media_type=media_type)
+def stream_mjpeg():
+    cam = _init_camera_if_needed()
+    if cam is None:
+        return JSONResponse(
+            {"ok": False, "reason": _CAMERA_ERROR or "camera_unavailable"},
+            status_code=503,
+        )
+    boundary = b"--frame\r\n"
+
+    def gen():
+        while True:
+            arr = cam.capture_array()
+            b = io.BytesIO()
+            Image.fromarray(arr).save(b, format="JPEG", quality=80)
+            yield boundary + b"Content-Type: image/jpeg\r\n\r\n" + b.getvalue() + b"\r\n"
+            time.sleep(1 / 12)
+
+    return StreamingResponse(gen(), media_type="multipart/x-mixed-replace; boundary=frame")


### PR DESCRIPTION
## Summary
- guard Picamera2 initialization with a global lock and cached error state
- add camera health endpoint and improved JPEG/JSON responses for capture and stream routes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2b47e53e88326a91eb9db94276078