### PR TITLE
Restore Picamera2 capture locking

### DIFF
--- a/backend/camera.py
+++ b/backend/camera.py
@@ -61,7 +61,8 @@ def capture_jpeg():
             status_code=503,
         )
     try:
-        arr = cam.capture_array()
+        with _CAMERA_LOCK:
+            arr = cam.capture_array()
         buf = io.BytesIO()
         Image.fromarray(arr).save(buf, format="JPEG", quality=85)
         return Response(content=buf.getvalue(), media_type="image/jpeg")
@@ -84,7 +85,8 @@ def stream_mjpeg():
 
     def gen():
         while True:
-            arr = cam.capture_array()
+            with _CAMERA_LOCK:
+                arr = cam.capture_array()
             b = io.BytesIO()
             Image.fromarray(arr).save(b, format="JPEG", quality=80)
             yield boundary + b"Content-Type: image/jpeg\r\n\r\n" + b.getvalue() + b"\r\n"


### PR DESCRIPTION
## Summary
- guard Picamera2 capture_array calls with the shared camera lock in capture and stream handlers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2b5c2cc0c8326a2eda434692e6d4b