### PR TITLE
Preserve Piper voice filename matching

### DIFF
--- a/backend/voice.py
+++ b/backend/voice.py
@@ -172,7 +172,12 @@ def _synthesize_to_file(text: str, voice: Optional[str]) -> Tuple[Path, str]:
         model_entry: Optional[dict] = None
         if voice:
             for candidate_model in models:
-                if voice == candidate_model["id"] or voice == candidate_model["path"]:
+                candidate_path = Path(candidate_model["path"])
+                if (
+                    voice == candidate_model["id"]
+                    or voice == candidate_model["path"]
+                    or voice == candidate_path.name
+                ):
                     model_entry = candidate_model
                     break
             else:


### PR DESCRIPTION
## Summary
- allow Piper voice selection to match advertised filename values in addition to ids and paths

## Testing
- python -m compileall backend/voice.py

------
https://chatgpt.com/codex/tasks/task_e_68e2bb15e2ec8326b366835028ef806b