### PR TITLE
Ensure nav safe exit buttons close timer and recipe views

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -165,9 +165,9 @@ const Index = () => {
       case "scanner":
         return <FoodScannerView />;
       case "timer":
-        return <TimerFullView />;
+        return <TimerFullView onClose={handleBackToMenu} />;
       case "recipes":
-        return <RecipesView />;
+        return <RecipesView onClose={handleBackToMenu} />;
       case "settings":
         return <SettingsView />;
       default:

--- a/src/pages/RecipesView.tsx
+++ b/src/pages/RecipesView.tsx
@@ -69,7 +69,7 @@ const mapIngredients = (recipe: GeneratedRecipe | null): IngredientDisplay[] => 
 };
 
 export const RecipesView = ({ context = "page", onClose }: RecipesViewProps = {}) => {
-  const { navEnabled, isTouchDevice, goBack, handleClose, isModal } = useNavSafeExit({
+  const { navEnabled, isTouchDevice, handleClose, isModal } = useNavSafeExit({
     context,
     onClose,
   });
@@ -268,7 +268,7 @@ export const RecipesView = ({ context = "page", onClose }: RecipesViewProps = {}
 
   const navControls = navEnabled ? (
     <div className="flex items-center gap-2 p-4">
-      <Button variant="outline" onClick={goBack} className="gap-2">
+      <Button variant="outline" onClick={handleClose} className="gap-2">
         <ArrowLeft className="h-4 w-4" />
         Atrás
       </Button>
@@ -499,7 +499,7 @@ export const RecipesView = ({ context = "page", onClose }: RecipesViewProps = {}
         <Button
           variant="glow"
           size="lg"
-          onClick={goBack}
+          onClick={handleClose}
           className="fixed bottom-6 right-6 z-50 rounded-full px-6 py-6 shadow-lg"
         >
           Salir

--- a/src/pages/TimerFullView.tsx
+++ b/src/pages/TimerFullView.tsx
@@ -18,7 +18,7 @@ interface TimerFullViewProps {
 }
 
 export const TimerFullView = ({ context = "page", onClose }: TimerFullViewProps = {}) => {
-  const { navEnabled, isTouchDevice, goBack, handleClose, isModal } = useNavSafeExit({
+  const { navEnabled, isTouchDevice, handleClose, isModal } = useNavSafeExit({
     context,
     onClose,
   });
@@ -174,7 +174,7 @@ export const TimerFullView = ({ context = "page", onClose }: TimerFullViewProps 
 
   const navControls = navEnabled ? (
     <div className="flex items-center gap-2 p-4">
-      <Button variant="outline" onClick={goBack} className="gap-2">
+      <Button variant="outline" onClick={handleClose} className="gap-2">
         <ArrowLeft className="h-4 w-4" />
         Atrás
       </Button>
@@ -373,7 +373,7 @@ export const TimerFullView = ({ context = "page", onClose }: TimerFullViewProps 
         <Button
           variant="glow"
           size="lg"
-          onClick={goBack}
+          onClick={handleClose}
           className="fixed bottom-6 right-6 z-50 rounded-full px-6 py-6 shadow-lg"
         >
           Salir


### PR DESCRIPTION
## Summary
- route the timer and recipes safe exit controls through the shared close handler so they trigger view shutdowns
- provide Index with onClose callbacks for TimerFullView and RecipesView to reset back to the menu

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e35f40dfa883268a0b57db9ef873c8