### PR TITLE
Add voice selector UI with TTS testing options

### DIFF
--- a/src/hooks/useVoice.ts
+++ b/src/hooks/useVoice.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from "react";
 import { api } from "@/services/api";
+import { storage } from "@/services/storage";
 
 interface UseVoiceReturn {
   speak: (text: string) => Promise<void>;
@@ -18,7 +19,8 @@ export const useVoice = (enabled: boolean): UseVoiceReturn => {
       try {
         setIsSpeaking(true);
         setError(null);
-        await api.speak(text);
+        const voiceId = storage.getSettings().voiceId;
+        await api.speak(text, voiceId ?? undefined);
       } catch (err) {
         console.error("Failed to speak:", err);
         setError("Error al reproducir voz");

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -172,7 +172,18 @@ class ApiService {
 
   // Voice/TTS endpoints
   async speak(text: string, voice?: string): Promise<void> {
-    await apiWrapper.post('/api/voice/speak', { text, voice });
+    const payload = voice ? { text, voice } : { text };
+
+    try {
+      await apiWrapper.post('/api/voice/speak', payload);
+    } catch {
+      const params = new URLSearchParams({ text });
+      if (voice) {
+        params.set('voice', voice);
+      }
+
+      await apiWrapper.post(`/api/voice/tts/say?${params.toString()}`);
+    }
   }
 
   // Recipe endpoints

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -58,9 +58,10 @@ export interface AppSettings {
   targetGlucose: number;
   hypoAlarm: number;
   hyperAlarm: number;
-  
+
   // UI settings
   isVoiceActive: boolean;
+  voiceId?: string;
   theme: 'dark' | 'light';
   ui: UiSettings;
 }
@@ -316,6 +317,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   hypoAlarm: 70,
   hyperAlarm: 180,
   isVoiceActive: false,
+  voiceId: undefined,
   theme: 'dark',
   ui: {
     flags: { ...DEFAULT_FEATURE_FLAGS },


### PR DESCRIPTION
## Summary
- add a feature-flagged voice selector that pulls the available Piper or eSpeak voices and exposes device/browser test buttons plus a beep control
- persist the chosen voice id in settings and ensure api.speak/useVoice include it for playback, falling back to the new TTS endpoints when needed
- extend settings storage defaults with the new voice preference

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e35e1ad4d8832683ed832726d8f434