### PR TITLE
feat: refresh calibration assistant flow

### DIFF
--- a/src/pages/SettingsView.tsx
+++ b/src/pages/SettingsView.tsx
@@ -992,32 +992,34 @@ export const SettingsView = () => {
                   Factor de calibración actual: {calibrationFactor}
                 </p>
                 <div className="flex gap-2">
-                <Input
-                  type="text"
-                  value={calibrationFactor}
-                  readOnly
-                  onClick={() => openKeyboard("Factor de Calibración", "numeric", "calibrationFactor", true, 0.1, 10000)}
-                  placeholder="Nuevo factor"
-                  className="flex-1 text-lg cursor-pointer"
-                />
-                  <Button 
-                    size="lg" 
-                    variant="secondary"
-                    onClick={() => setShowCalibrationWizard(true)}
-                  >
-                    Calibrar
-                  </Button>
+                  <Input
+                    type="text"
+                    value={calibrationFactor}
+                    readOnly
+                    onClick={() => openKeyboard("Factor de Calibración", "numeric", "calibrationFactor", true, 0.1, 10000)}
+                    placeholder="Nuevo factor"
+                    className="flex-1 cursor-pointer text-lg"
+                  />
+                  {!featureFlags.calibrationV2 && (
+                    <Button
+                      size="lg"
+                      variant="secondary"
+                      onClick={() => setShowCalibrationWizard(true)}
+                    >
+                      Calibrar
+                    </Button>
+                  )}
                 </div>
               </div>
 
-              <Button 
-                variant="glow" 
-                size="lg" 
+              <Button
+                variant="glow"
+                size="lg"
                 className="w-full"
                 onClick={() => setShowCalibrationWizard(true)}
               >
                 <Scale className="mr-2 h-5 w-5" />
-                Ejecutar Asistente de Calibración
+                {featureFlags.calibrationV2 ? "Asistente de calibración" : "Ejecutar Asistente de Calibración"}
               </Button>
             </div>
           </Card>
@@ -1402,6 +1404,7 @@ export const SettingsView = () => {
         open={showCalibrationWizard}
         onClose={() => setShowCalibrationWizard(false)}
         currentWeight={weight}
+        isCalibrationV2={featureFlags.calibrationV2}
       />
     </div>
   );

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -85,6 +85,15 @@ class ApiService {
     await apiWrapper.post('/api/scale/calibrate', { factor });
   }
 
+  async applyCalibration(
+    referenceGrams: number
+  ): Promise<{ ok: boolean; message?: string; calibration_factor?: number }> {
+    return apiWrapper.post<{ ok: boolean; message?: string; calibration_factor?: number }>(
+      '/api/scale/calibrate/apply',
+      { reference_grams: referenceGrams }
+    );
+  }
+
   // Food scanner endpoints
   async analyzeFood(imageBlob: Blob, weight: number): Promise<FoodAnalysis> {
     // FormData needs special handling, use native fetch


### PR DESCRIPTION
## Summary
- implement the calibration v2 two-step assistant with the new apply endpoint and updated success/error toasts
- rename the tare control to a Cero action with updated messaging when calibration v2 is active
- add backend and miniweb handlers for /api/scale/calibrate/apply and stubbed tare responses when no scale service exists

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e36569cd1c8326ad799e70ce6ed3a8