### PR TITLE
Improve MINI-EB handling and OTA status UI

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -222,8 +222,8 @@ class ApiService {
   }
 
   // OTA Updates
-  async checkUpdates(): Promise<{ available: boolean; version?: string }> {
-    return apiWrapper.get<{ available: boolean; version?: string }>('/api/updates/check');
+  async getOtaStatus(): Promise<{ current: string; latest: string; hasUpdate: boolean }> {
+    return apiWrapper.get<{ current: string; latest: string; hasUpdate: boolean }>('/api/ota/check');
   }
 
   async installUpdate(): Promise<void> {


### PR DESCRIPTION
## Summary
- add resilient MINI-EB status retrieval with timeout, retries, and debug-aware logging
- surface MINI-EB loading/error/ready states in settings with retry controls and QR rendering only when ready
- fetch OTA status from /api/ota/check and render current/latest versions while gating installation behind the otaApply flag

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e37326755c8326bbcba8c4a98e0ae8