### PR TITLE
feat: implement OTA apply workflow with UI and background worker

### DIFF
--- a/src/components/RecoveryMode.tsx
+++ b/src/components/RecoveryMode.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, RotateCcw, Download, Power } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { api } from "@/services/api";
+import { ApiError } from "@/services/apiWrapper";
 import { useToast } from "@/hooks/use-toast";
 
 export const RecoveryMode = () => {
@@ -12,20 +13,27 @@ export const RecoveryMode = () => {
   const handleUpdate = async () => {
     setIsUpdating(true);
     try {
-      await api.installUpdate();
+      await api.applyOtaUpdate();
       toast({
         title: "Actualización iniciada",
-        description: "El sistema se reiniciará en 30 segundos",
+        description: "La reinstalación se está ejecutando en segundo plano",
       });
       setTimeout(() => {
         window.location.reload();
-      }, 30000);
+      }, 15000);
     } catch (error) {
-      toast({
-        title: "Error",
-        description: "No se pudo iniciar la actualización",
-        variant: "destructive",
-      });
+      if (error instanceof ApiError && error.status === 409) {
+        toast({
+          title: "Actualización en curso",
+          description: "Ya hay un proceso de reinstalación activo",
+        });
+      } else {
+        toast({
+          title: "Error",
+          description: "No se pudo iniciar la actualización",
+          variant: "destructive",
+        });
+      }
       setIsUpdating(false);
     }
   };

--- a/src/services/apiWrapper.ts
+++ b/src/services/apiWrapper.ts
@@ -36,6 +36,10 @@ class ApiWrapper {
     this.baseUrl = url;
   }
 
+  getBaseUrl(): string {
+    return this.baseUrl;
+  }
+
   private async fetchWithTimeout(
     url: string,
     options: RequestInit,


### PR DESCRIPTION
## Summary
- add an OTA worker that persists status, streams events, and tails logs for the miniweb backend
- expose apply, status, and logs endpoints while wiring a progress-oriented OTA UI with SSE/polling fallbacks
- update shared API helpers and the recovery mode flow to use the new OTA apply entry point

## Testing
- python -m compileall backend
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e376001b4883269c4fca72ccb9a93d