### PR TITLE
Fix OTA status mapping for new update API

### DIFF
--- a/src/pages/SettingsView.tsx
+++ b/src/pages/SettingsView.tsx
@@ -210,7 +210,12 @@ export const SettingsView = () => {
       return "—";
     }
 
-    return value.startsWith("v") ? value : `v${value}`;
+    const normalized = value.trim();
+    if (!normalized || normalized.toLowerCase() === "unknown") {
+      return "—";
+    }
+
+    return normalized.startsWith("v") ? normalized : `v${normalized}`;
   };
 
   const refreshNetworkStatus = useCallback(


### PR DESCRIPTION
## Summary
- map the /api/updates/check response into the OTA status shape expected by the UI
- fall back to the OTA job state to recover the current and target versions and normalize unknown values
- normalize version formatting in the settings view so placeholder text is shown when the version is unknown

## Testing
- npm run lint -- --max-warnings=0 *(fails: existing react-refresh warnings in shared UI components)*

------
https://chatgpt.com/codex/tasks/task_e_68e37ecafd6483269143e44ee1645ce6