### PR TITLE
Handle wake SSE events in Index page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -409,13 +409,24 @@ const Index = () => {
         }));
       };
 
-      source.onmessage = (messageEvent) => {
+      const handleSseMessage = (messageEvent: MessageEvent<string>) => {
         try {
           const payload = JSON.parse(messageEvent.data) as WakeEvent;
           void handleWakeEvent(payload);
         } catch (error) {
           console.error('Failed to parse wake event payload', error);
         }
+      };
+
+      source.addEventListener('wake', (event) => {
+        handleSseMessage(event as MessageEvent<string>);
+      });
+      source.addEventListener('intent', (event) => {
+        handleSseMessage(event as MessageEvent<string>);
+      });
+
+      source.onmessage = (messageEvent) => {
+        handleSseMessage(messageEvent as MessageEvent<string>);
       };
 
       source.onerror = () => {


### PR DESCRIPTION
## Summary
- add explicit listeners for `wake` and `intent` server-sent events so wake handling runs
- reuse a common parser for SSE payloads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e385f55e64832681d980562fcec642