### PR TITLE
Respect scale decimal preference across the UI

### DIFF
--- a/src/components/CalibrationWizard.tsx
+++ b/src/components/CalibrationWizard.tsx
@@ -10,6 +10,8 @@ import { cn } from "@/lib/utils";
 import { api } from "@/services/api";
 import { storage } from "@/services/storage";
 import { useToast } from "@/hooks/use-toast";
+import { formatWeight } from "@/lib/format";
+import { useScaleDecimals } from "@/hooks/useScaleDecimals";
 
 interface CalibrationWizardProps {
   open: boolean;
@@ -29,6 +31,7 @@ const CalibrationWizardV2 = ({ open, onClose, currentWeight }: CalibrationWizard
   const [referenceWeight, setReferenceWeight] = useState("100");
   const [isApplying, setIsApplying] = useState(false);
   const { toast } = useToast();
+  const decimals = useScaleDecimals();
 
   const resetWizard = () => {
     setStep(1);
@@ -62,7 +65,7 @@ const CalibrationWizardV2 = ({ open, onClose, currentWeight }: CalibrationWizard
 
         toast({
           title: "Calibración aplicada",
-          description: response.message ?? `Referencia registrada: ${parsedReference.toFixed(1)} g`,
+          description: response.message ?? `Referencia registrada: ${formatWeight(parsedReference, decimals)} g`,
         });
 
         if (navigator.vibrate) {
@@ -129,8 +132,11 @@ const CalibrationWizardV2 = ({ open, onClose, currentWeight }: CalibrationWizard
                 </p>
               </div>
 
-              <div className={cn("text-6xl font-bold", hasReferenceOnScale ? "text-primary" : "text-muted-foreground")}> 
-                {currentWeight.toFixed(1)} g
+              <div
+                className={cn("text-6xl font-bold", hasReferenceOnScale ? "text-primary" : "text-muted-foreground")}
+                style={{ fontFeatureSettings: '"tnum"' }}
+              >
+                {formatWeight(currentWeight, decimals)} g
               </div>
 
               {!hasReferenceOnScale && (
@@ -181,7 +187,12 @@ const CalibrationWizardV2 = ({ open, onClose, currentWeight }: CalibrationWizard
 
               <div className="text-center">
                 <p className="mb-2 text-sm text-muted-foreground">Lectura actual</p>
-                <div className="text-5xl font-bold text-primary">{currentWeight.toFixed(1)} g</div>
+                <div
+                  className="text-5xl font-bold text-primary"
+                  style={{ fontFeatureSettings: '"tnum"' }}
+                >
+                  {formatWeight(currentWeight, decimals)} g
+                </div>
               </div>
 
               <div className="grid grid-cols-2 gap-4">
@@ -212,6 +223,7 @@ const CalibrationWizardLegacy = ({ open, onClose, currentWeight }: CalibrationWi
   const [rawValue, setRawValue] = useState(0);
   const [calibrationFactor, setCalibrationFactor] = useState(0);
   const { toast } = useToast();
+  const decimals = useScaleDecimals();
 
   const resetWizard = () => {
     setStep(1);
@@ -321,8 +333,9 @@ const CalibrationWizardLegacy = ({ open, onClose, currentWeight }: CalibrationWi
                   "text-6xl font-bold",
                   currentWeight === 0 ? "text-success" : "text-warning"
                 )}
+                style={{ fontFeatureSettings: '"tnum"' }}
               >
-                {currentWeight.toFixed(1)} g
+                {formatWeight(currentWeight, decimals)} g
               </div>
 
               <Button
@@ -376,8 +389,11 @@ const CalibrationWizardLegacy = ({ open, onClose, currentWeight }: CalibrationWi
 
               <div className="text-center">
                 <p className="text-sm text-muted-foreground mb-2">Lectura actual:</p>
-                <div className="text-5xl font-bold text-primary">
-                  {currentWeight.toFixed(1)} g
+                <div
+                  className="text-5xl font-bold text-primary"
+                  style={{ fontFeatureSettings: '"tnum"' }}
+                >
+                  {formatWeight(currentWeight, decimals)} g
                 </div>
               </div>
 
@@ -425,7 +441,9 @@ const CalibrationWizardLegacy = ({ open, onClose, currentWeight }: CalibrationWi
                 </div>
                 <div>
                   <p className="text-sm text-muted-foreground">Valor medido:</p>
-                  <p className="text-2xl font-bold">{rawValue.toFixed(1)} g</p>
+                  <p className="text-2xl font-bold" style={{ fontFeatureSettings: '"tnum"' }}>
+                    {formatWeight(rawValue, decimals)} g
+                  </p>
                 </div>
                 <div className="border-t border-border pt-4">
                   <p className="text-sm text-muted-foreground">Factor de calibración:</p>

--- a/src/components/WeightHistoryDialog.tsx
+++ b/src/components/WeightHistoryDialog.tsx
@@ -4,6 +4,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Trash2, Calendar } from "lucide-react";
 import { useWeightHistory } from "@/hooks/useWeightHistory";
 import { Skeleton } from "@/components/ui/skeleton";
+import { formatWeight } from "@/lib/format";
+import { useScaleDecimals } from "@/hooks/useScaleDecimals";
 
 interface WeightHistoryDialogProps {
   open: boolean;
@@ -12,6 +14,7 @@ interface WeightHistoryDialogProps {
 
 export const WeightHistoryDialog = ({ open, onClose }: WeightHistoryDialogProps) => {
   const { history, isLoading, deleteRecord, clearHistory } = useWeightHistory();
+  const decimals = useScaleDecimals();
 
   const formatDate = (timestamp: number) => {
     const date = new Date(timestamp);
@@ -81,8 +84,8 @@ export const WeightHistoryDialog = ({ open, onClose }: WeightHistoryDialogProps)
                   >
                     <div className="flex-1">
                       <div className="flex items-baseline gap-3 mb-1">
-                        <span className="text-3xl font-bold text-primary">
-                          {record.weight.toFixed(1)}
+                        <span className="text-3xl font-bold text-primary" style={{ fontFeatureSettings: '"tnum"' }}>
+                          {formatWeight(record.weight, decimals)}
                         </span>
                         <span className="text-lg text-muted-foreground">
                           {record.unit}

--- a/src/hooks/useScaleDecimals.ts
+++ b/src/hooks/useScaleDecimals.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { storage, type AppSettings, SETTINGS_STORAGE_KEY } from '@/services/storage';
+
+const readDecimals = (): 0 | 1 => {
+  try {
+    const settings = storage.getSettings();
+    const value = settings.scale?.decimals;
+    return value === 0 ? 0 : 1;
+  } catch (error) {
+    return 1;
+  }
+};
+
+export const useScaleDecimals = (): 0 | 1 => {
+  const [decimals, setDecimals] = useState<0 | 1>(() => readDecimals());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleUpdate: EventListener = (event) => {
+      const detail = (event as CustomEvent<{ settings?: AppSettings }>).detail;
+      const next = detail?.settings?.scale?.decimals;
+
+      if (next === 0 || next === 1) {
+        setDecimals(next);
+        return;
+      }
+
+      setDecimals(readDecimals());
+    };
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key && event.key !== SETTINGS_STORAGE_KEY) {
+        return;
+      }
+      setDecimals(readDecimals());
+    };
+
+    window.addEventListener('app-settings-updated', handleUpdate);
+    window.addEventListener('storage', handleStorage);
+
+    return () => {
+      window.removeEventListener('app-settings-updated', handleUpdate);
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  return decimals;
+};

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,20 @@
+export function formatWeight(
+  grams: number | null | undefined,
+  decimals: 0 | 1,
+  locale = 'es-ES'
+): string {
+  if (grams == null || !Number.isFinite(grams as number)) {
+    return '–';
+  }
+
+  const n = Number(grams);
+  const displayValue = decimals === 0 && Math.abs(n) < 0.5 ? 0 : n;
+
+  const opts: Intl.NumberFormatOptions = {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+    useGrouping: false,
+  };
+
+  return new Intl.NumberFormat(locale, opts).format(displayValue / 1);
+}

--- a/src/pages/FoodScannerView.tsx
+++ b/src/pages/FoodScannerView.tsx
@@ -12,6 +12,8 @@ import { logger } from "@/services/logger";
 import { api } from "@/services/api";
 import { ApiError } from "@/services/apiWrapper";
 import { buildFoodItem, toFoodItem, type FoodScannerConfirmedPayload, type FoodItem } from "@/features/food-scanner/foodItem";
+import { formatWeight } from "@/lib/format";
+import { useScaleDecimals } from "@/hooks/useScaleDecimals";
 
 export const FoodScannerView = () => {
   const { weight: scaleWeight } = useScaleWebSocket();
@@ -35,6 +37,11 @@ export const FoodScannerView = () => {
   const preservedScannerEntriesRef = useRef<ScannerHistoryEntry[]>([]);
 
   const { toast } = useToast();
+  const decimals = useScaleDecimals();
+  const renderWeight = (value: number | null | undefined) => {
+    const formatted = formatWeight(value, decimals);
+    return formatted === '–' ? formatted : `${formatted} g`;
+  };
 
   const settings = storage.getSettings();
   const isDiabetesMode = settings.diabetesMode;
@@ -264,7 +271,7 @@ export const FoodScannerView = () => {
     setFoods((prev) => [...prev, item]);
     setSelectedId(item.id);
     logger.info("Food registered", { name: item.name, weight: item.weight, source: item.source });
-    toast({ title: "Alimento añadido", description: `${item.name} - ${item.weight.toFixed(1)} g` });
+    toast({ title: "Alimento añadido", description: `${item.name} - ${renderWeight(item.weight)}` });
     if (navigator.vibrate) {
       navigator.vibrate(25);
     }
@@ -349,7 +356,7 @@ export const FoodScannerView = () => {
     });
     toast({
       title: "Resumen guardado",
-      description: `Peso total: ${totals.weight.toFixed(1)} g`
+      description: `Peso total: ${renderWeight(totals.weight)}`
     });
   };
 
@@ -398,8 +405,8 @@ export const FoodScannerView = () => {
             <div className="mb-4 flex items-center justify-between">
               <div>
                 <h2 className="text-2xl font-bold">Captura con cámara</h2>
-                <p className="text-sm text-muted-foreground">
-                  Peso detectado: {scaleWeight.toFixed(1)} g
+                <p className="text-sm text-muted-foreground" style={{ fontFeatureSettings: '"tnum"' }}>
+                  Peso detectado: {renderWeight(scaleWeight)}
                 </p>
               </div>
               <div className="flex gap-2">
@@ -514,7 +521,9 @@ export const FoodScannerView = () => {
                         )}
                       </p>
                     </div>
-                    <span className="text-xl font-bold text-primary">{food.weight.toFixed(1)} g</span>
+                    <span className="text-xl font-bold text-primary" style={{ fontFeatureSettings: '"tnum"' }}>
+                      {renderWeight(food.weight)}
+                    </span>
                   </div>
 
                   <div className="grid grid-cols-5 gap-2 text-sm">
@@ -572,7 +581,9 @@ export const FoodScannerView = () => {
             <div className="mb-4 grid grid-cols-4 gap-4 text-center">
               <div>
                 <p className="text-sm text-muted-foreground">Peso</p>
-                <p className="text-2xl font-bold text-primary">{totals.weight.toFixed(1)} g</p>
+                <p className="text-2xl font-bold text-primary" style={{ fontFeatureSettings: '"tnum"' }}>
+                  {renderWeight(totals.weight)}
+                </p>
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">HC</p>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -19,6 +19,8 @@ import { networkDetector, NetworkStatus } from "@/services/networkDetector";
 import { api, type WakeEvent, type WakeStatus } from "@/services/api";
 import { apiWrapper } from "@/services/apiWrapper";
 import { storage, type AppSettings } from "@/services/storage";
+import { formatWeight } from "@/lib/format";
+import { useScaleDecimals } from "@/hooks/useScaleDecimals";
 
 const Index = () => {
   const [currentView, setCurrentView] = useState<string>("menu");
@@ -43,6 +45,7 @@ const Index = () => {
   const wakeOverlayTimeoutRef = useRef<number | null>(null);
   const wakeEventSourceRef = useRef<EventSource | null>(null);
   const wakeReconnectTimeoutRef = useRef<number | null>(null);
+  const scaleDecimals = useScaleDecimals();
 
   // Monitor glucose if diabetes mode is enabled
   const glucoseData = useGlucoseMonitor(diabetesMode);
@@ -239,8 +242,9 @@ const Index = () => {
             const response = await api.getScaleWeight();
             const value = typeof response.value === 'number' ? response.value : null;
             if (value !== null) {
-              const formatted = value.toFixed(1);
-              setMascoMsg(`Peso estable: ${formatted} gramos.`);
+              const formatted = formatWeight(value, scaleDecimals);
+              const messageWeight = formatted === '–' ? formatted : `${formatted} gramos`;
+              setMascoMsg(`Peso estable: ${messageWeight}.`);
               setBasculinMood("happy");
             } else {
               setMascoMsg("No detecto peso estable ahora mismo.");
@@ -300,7 +304,7 @@ const Index = () => {
           return;
       }
     },
-    [handleTimerStart]
+    [handleTimerStart, scaleDecimals]
   );
 
   useEffect(() => {

--- a/src/pages/SettingsView.tsx
+++ b/src/pages/SettingsView.tsx
@@ -372,7 +372,7 @@ export const SettingsView = () => {
     setWakeWordEnabled(settings.wakeWordEnabled ?? false);
     setDiabetesMode(settings.diabetesMode);
     setCalibrationFactor(settings.calibrationFactor.toString());
-    setDecimals(settings.decimals?.toString() || "1");
+    setDecimals(settings.scale?.decimals?.toString() ?? "1");
     setApiUrl(settings.apiUrl);
     setWsUrl(settings.wsUrl);
     setChatGptKey(settings.chatGptKey);
@@ -732,7 +732,7 @@ export const SettingsView = () => {
   const handleKeyboardConfirm = () => {
     const setters: Record<string, (value: string) => void> = {
       calibrationFactor: setCalibrationFactor,
-      decimals: setDecimals,
+      decimals: (value: string) => setDecimals(parseDecimalsPreference(value).toString()),
       chatGptKey: setChatGptKey,
       nightscoutUrl: setNightscoutUrl,
       nightscoutToken: setNightscoutToken,
@@ -765,7 +765,7 @@ export const SettingsView = () => {
       if (field === 'calibrationFactor') {
         storage.saveSettings({ calibrationFactor: parseFloat(tempValue) || 1 });
       } else if (field === 'decimals') {
-        storage.saveSettings({ decimals: parseInt(tempValue) || 1 });
+        storage.saveSettings({ scale: { decimals: parseDecimalsPreference(tempValue) } });
       } else if (field === 'chatGptKey') {
         storage.saveSettings({ chatGptKey: tempValue });
       } else if (field === 'nightscoutUrl') {
@@ -1692,8 +1692,9 @@ export const SettingsView = () => {
                   className="w-full rounded-lg border border-input bg-background px-4 py-3 text-lg"
                   value={decimals}
                   onChange={(e) => {
-                    setDecimals(e.target.value);
-                    storage.saveSettings({ decimals: parseInt(e.target.value) });
+                    const nextDecimals = parseDecimalsPreference(e.target.value);
+                    setDecimals(nextDecimals.toString());
+                    storage.saveSettings({ scale: { decimals: nextDecimals } });
                     toast({
                       title: "Guardado",
                       description: "Preferencia de decimales actualizada",
@@ -2565,3 +2566,11 @@ sudo systemctl restart bascula-miniweb bascula-app`}
     </div>
   );
 };
+  const parseDecimalsPreference = (value: string): 0 | 1 => {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isNaN(parsed)) {
+      return 1;
+    }
+    return parsed >= 1 ? 1 : 0;
+  };
+


### PR DESCRIPTION
## Summary
- store the decimal preference under `scale.decimals` with migration and normalization logic
- add shared helpers to format weights and subscribe to the current decimal setting
- update scale, scanner, calibration, history, index, and settings views to render weights via the new helper and tabular numerals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3869e3d5c83268b4b6020a9a9fa8a