### PR TITLE
Show Basculin mascot on home screen

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -159,6 +159,7 @@ const Index = () => {
     setCurrentView("menu");
     setTimerSeconds(undefined);
     setBasculinMood("sleeping");
+    setMascoMsg(undefined);
   };
 
   const handleNavigate = (view: string) => {
@@ -481,6 +482,7 @@ const Index = () => {
   };
 
   const showTopBar = currentView !== "menu" && currentView !== "timer" && currentView !== "recipes";
+  const shouldShowMascot = !showRecovery && !showAPMode;
 
   // Show special screens first
   if (showRecovery) {
@@ -503,7 +505,7 @@ const Index = () => {
 
       {/* Basculin Mascot */}
       <BasculinMascot
-        isActive={currentView !== "menu"}
+        isActive={shouldShowMascot}
         message={mascoMsg}
         position="corner"
         mood={basculinMood}


### PR DESCRIPTION
## Summary
- always render the Basculin mascot on the main menu screen instead of hiding it there
- clear any previous mascot speech bubble when returning to the menu so it rests quietly

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e3954c41b88326bc161c733525bf67