### PR TITLE
feat: add local OpenAI and Nightscout settings

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,5 +1,5 @@
 // Se sustituye en build por install-all.sh
-const CACHE_VERSION = "v0.0.0-nogit";
+const CACHE_VERSION = "v0.0.0-36c93b2";
 const STATIC_CACHE = `bascula-static-${CACHE_VERSION}`;
 const PRECACHE_ASSETS = [
   '/manifest.json',


### PR DESCRIPTION
## Summary
- add FastAPI endpoints to persist OpenAI and Nightscout credentials locally and expose connectivity checks
- load stored credentials in the main backend configuration to drive ChatGPT and Nightscout features
- extend the mini-web configuration UI with external services forms, inline tests, and local-only storage messaging

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3a3bff4e88326915f5ec84920587b