### PR TITLE
Expose AP info endpoint and sync AP mode UI

### DIFF
--- a/src/pages/SettingsView.tsx
+++ b/src/pages/SettingsView.tsx
@@ -1791,7 +1791,7 @@ export const SettingsView = () => {
                     <div className="space-y-1">
                       <p className="font-semibold text-warning-foreground">Modo recuperación activo</p>
                       <p className="text-sm text-warning-foreground/80">
-                        La báscula está emitiendo la Wi-Fi "Bascula-Setup". Usa la mini-web para conectarla a tu red habitual.
+                        La báscula está emitiendo la Wi-Fi "Bascula-AP". Usa la mini-web para conectarla a tu red habitual.
                       </p>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- add a backend `/api/ap/info` endpoint that reads the active AP SSID from the nmconnection or ensure script and returns the device IP and config path
- update the AP mode screen to fetch the new endpoint, show loading placeholders, and render the correct SSID and config URL
- replace the remaining "Bascula-Setup" copy with "Bascula-AP" in the settings recovery banner

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3a729c48c8326a28d55020063e477