### PR TITLE
Restore automatic transition from AP to kiosk UI after Wi-Fi connect

### DIFF
--- a/scripts/start-kiosk.sh
+++ b/scripts/start-kiosk.sh
@@ -9,6 +9,51 @@ xset s noblank
 # Hide cursor after inactivity
 unclutter -idle 5 -root &
 
+# Determine target URL based on miniweb status
+resolve_target_url() {
+  python3 <<'PY'
+import json
+import time
+import urllib.error
+import urllib.request
+
+STATUS_URL = "http://127.0.0.1:8080/api/miniweb/status"
+
+
+def choose_url() -> str:
+    for _ in range(20):
+        try:
+            with urllib.request.urlopen(STATUS_URL, timeout=2) as response:
+                data = json.load(response)
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, json.JSONDecodeError):
+            time.sleep(1)
+            continue
+        except Exception:
+            time.sleep(1)
+            continue
+
+        mode = str(data.get("mode") or "").lower()
+        wifi = data.get("wifi") or {}
+        wifi_connected = bool(wifi.get("connected"))
+        wifi_ip = wifi.get("ip") or data.get("ip") or data.get("ip_address")
+        ethernet_connected = bool(data.get("ethernet_connected"))
+
+        if mode == "kiosk" or (wifi_connected and wifi_ip) or ethernet_connected:
+            return "http://localhost/"
+        if mode == "ap":
+            return "http://localhost/config"
+
+        time.sleep(1)
+
+    return "http://localhost/config"
+
+
+print(choose_url())
+PY
+}
+
+TARGET_URL="$(resolve_target_url)"
+
 # Start Chromium in kiosk mode
 chromium \
   --kiosk \
@@ -23,4 +68,4 @@ chromium \
   --start-fullscreen \
   --window-size=1024,600 \
   --window-position=0,0 \
-  http://localhost
+  "$TARGET_URL"

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -105,6 +105,21 @@ export interface WakeEvent {
   simulated?: boolean;
 }
 
+export type MiniwebStatus = {
+  ok: boolean;
+  mode: "ap" | "kiosk";
+  wifi: {
+    connected: boolean;
+    ssid?: string | null;
+    ip?: string | null;
+  };
+  ap_active?: boolean;
+  connectivity?: string;
+  ssid?: string | null;
+  ip?: string | null;
+  ip_address?: string | null;
+} & Record<string, unknown>;
+
 class ApiService {
   constructor() {
     // Update API base URL from settings
@@ -362,6 +377,10 @@ class ApiService {
   // Network endpoints
   async getNetworkStatus(): Promise<{ ip: string; ssid?: string }> {
     return apiWrapper.get<{ ip: string; ssid?: string }>('/api/network/status');
+  }
+
+  async miniwebStatus(): Promise<MiniwebStatus> {
+    return apiWrapper.get<MiniwebStatus>('/api/miniweb/status');
   }
 }
 


### PR DESCRIPTION
## Summary
- add asynchronous network event broadcasting, stronger Wi-Fi validation, and system service actions to miniweb when a client joins successfully
- expose /api/net/events SSE plus richer /api/miniweb/status data, wire up the AP screen with SSE+polling auto redirect, and add a miniwebStatus API helper
- surface a timed “Intentando conexión…” message while connecting and update the kiosk launcher script to pick / or /config based on the reported mode

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3be7b7b588326bf6a3643655fce89