### PR TITLE
Fix AP mode redirect to use UI origin

### DIFF
--- a/src/components/APModeScreen.tsx
+++ b/src/components/APModeScreen.tsx
@@ -46,13 +46,11 @@ export const APModeScreen = () => {
   const redirectRef = useRef(false);
 
   const resolveAppBaseUrl = useCallback(() => {
-    const candidate = apiWrapper.getBaseUrl();
-    const fallback = typeof window !== "undefined" ? window.location.origin : "";
-    const base = (candidate && candidate.trim()) || fallback || "";
-    if (!base) {
+    if (typeof window === "undefined" || !window.location?.origin) {
       return "/";
     }
-    return `${base.replace(/\/+$/, "")}/`;
+
+    return `${window.location.origin.replace(/\/+$/, "")}/`;
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- derive the application base URL from the browser origin instead of the API base for AP mode redirects
- keep AP mode redirects pointed at the UI home regardless of API host differences

## Testing
- npm run lint

## Prompt para Codex (pégalo en el PR)

Objetivo
Corregir el handoff del modo AP para que la navegación vaya siempre a la UI (origen del navegador), no al host del API.

Alcance
src/components/APModeScreen.tsx (y utilidades relacionadas en apiWrapper/config si aplica).

Cambios requeridos

Separar bases:

Mantener apiBase solo para fetch/axios (miniweb).

Derivar uiBase de window.location.origin (o document.location.origin) y no de apiBase.

Si estamos en el portal de onboarding (p. ej. http://192.168.4.1:8080/config), la UI base debe seguir siendo el origen de la página cargada.

Redirección tras conexión:

En APModeScreen, cuando wifi_connected (SSE) o net/status.online === true, navegar a ${uiBase}/ (o a la ruta de Home definida), nunca a ${apiBase}.

El helper resolveAppBaseUrl() debe priorizar window.location.origin. Si window no existe (SSR/build), devolver /.

El apiWrapper.getBaseUrl() debe usarse solo para llamadas a API, no para window.location.

Casos borde:

apiBase distinto de uiBase (127.0.0.1:8080 vs localhost).

Onboarding en AP (192.168.4.1) → uiBase = http(s)://192.168.4.1:8080.

Quitar replace(/\/+$/, "") duplicado que genere // en rutas.

Criterios de aceptación

En modo AP, al configurar una Wi-Fi válida, la pantalla redirige automáticamente a la UI (Home) en <10 s sin reinicio manual.

Ya no se navega a http://127.0.0.1:8080/ tras el evento wifi_connected.

No hay errores en consola del navegador del kiosk relativos a navegación/permiso CORS.

Notas

Mantén polling/SSE como está; solo corrige el destino de la navegación.

No toques nombres de servicios ni lógica AP fuera de esto.

------
https://chatgpt.com/codex/tasks/task_e_68e3cecab5d88326b8f7b243311b290e