### PR TITLE
Fix kiosk startup dependencies and document audio defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ Tras el reinicio:
 - El PIN de acceso se muestra en la pantalla principal y puede consultarse desde `/api/miniweb/pin` cuando se accede localmente.
 - Si no hay Wi-Fi ni Ethernet, `bascula-ap-ensure.service` levanta `Bascula-AP` (`192.168.4.1`) con clave `Bascula1234` para exponer la miniweb en `http://192.168.4.1:8080`. 【F:scripts/bascula-ap-ensure.sh†L18-L115】
 
+### Configuración de audio (HifiBerry + micro USB)
+
+El instalador configura ALSA para priorizar la salida HifiBerry (card 1, `hw:1,0`) y el micrófono USB como captura por defecto. Se escribe `/etc/asound.conf` con los defaults globales y se instalan las utilidades necesarias (`alsa-utils`, `pulseaudio`, `sox`, `ffmpeg`) para poder probar TTS/STT de inmediato. 【F:scripts/install-all.sh†L212-L276】【F:scripts/install-all.sh†L640-L690】
+
+Tras reiniciar, valida el audio ejecutando desde la Raspberry Pi:
+
+```bash
+aplay -D hw:1,0 /usr/share/sounds/alsa/Front_Center.wav
+arecord -D hw:0,0 -f cd -c1 -r 44100 test.wav
+aplay -D hw:1,0 test.wav
+```
+
+Si cualquiera de los comandos falla, revisa `/etc/asound.conf` y que `aplay -l` detecte la tarjeta HifiBerry como `card 1` y el micrófono USB como `card 0`. 【F:scripts/install-all.sh†L212-L276】
+
 ### Dependencias Python críticas
 
 El backend y la miniweb requieren una serie de librerías que ahora se instalan desde `requirements.txt`. 【F:requirements.txt†L1-L20】

--- a/systemd/bascula-ui.service
+++ b/systemd/bascula-ui.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Bascula Digital Pro - UI (Chromium kiosk)
-After=systemd-user-sessions.service network-online.target bascula-miniweb.service
-Wants=network-online.target bascula-miniweb.service
+After=systemd-user-sessions.service network-online.target sound.target bascula-miniweb.service
+Wants=network-online.target sound.target bascula-miniweb.service
 Requires=bascula-miniweb.service
 Conflicts=getty@tty1.service
 StartLimitIntervalSec=0
@@ -24,6 +24,9 @@ StandardOutput=journal
 StandardError=journal
 PermissionsStartOnly=yes
 ExecStartPre=-/usr/bin/chvt 1
+ExecStartPre=/usr/bin/mkdir -p /var/log/bascula
+ExecStartPre=/usr/bin/test -f /var/log/bascula/ui.log || /usr/bin/install -o pi -g pi -m 0644 /dev/null /var/log/bascula/ui.log
+ExecStartPre=/usr/bin/chown pi:pi /var/log/bascula/ui.log
 ExecStart=/opt/bascula/current/scripts/start-kiosk-wrapper.sh
 Restart=always
 RestartSec=5


### PR DESCRIPTION
## Summary
- ensure the Chromium kiosk service waits for sound availability and prepares its log directory idempotently
- update the installer to provision pulseaudio tooling, write the global ALSA defaults, and fully remove the legacy bascula-app service
- document the audio verification steps for the HifiBerry DAC plus USB microphone workflow

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3fb18dd60832695b82371af1e6d9c