### PR TITLE
Ensure bascula-ui kiosk service uses validated override

### DIFF
--- a/systemd/bascula-ui.service
+++ b/systemd/bascula-ui.service
@@ -15,21 +15,12 @@ Environment=HOME=/home/pi
 Environment=USER=pi
 Environment=DISPLAY=:0
 Environment=XDG_RUNTIME_DIR=/run/user/1000
-TTYPath=/dev/tty1
-TTYReset=yes
-TTYVHangup=yes
-TTYVTDisallocate=yes
-StandardInput=tty
 StandardOutput=journal
 StandardError=journal
 PermissionsStartOnly=yes
-ExecStartPre=-/usr/bin/chvt 1
-ExecStartPre=/usr/bin/mkdir -p /var/log/bascula
-ExecStartPre=/usr/bin/test -f /var/log/bascula/ui.log || /usr/bin/install -o pi -g pi -m 0644 /dev/null /var/log/bascula/ui.log
-ExecStartPre=/usr/bin/chown pi:pi /var/log/bascula/ui.log
-ExecStart=/opt/bascula/current/scripts/start-kiosk-wrapper.sh
+ExecStart=/usr/bin/startx /opt/bascula/current/.xinitrc -- :0 vt1 -nocursor
 Restart=always
-RestartSec=5
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add a helper that writes the bascula-ui override.conf drop-in, validates it with systemd-analyze, reloads systemd, and runs required diagnostics
- update the installation flow to rely on the drop-in, avoid duplicate ExecStart directives, and keep legacy services disabled before restarting the kiosk
- simplify the base bascula-ui.service definition so startx is the only ExecStart with the desired restart delay

## Testing
- bash -n scripts/install-all.sh

------
https://chatgpt.com/codex/tasks/task_e_68e407cf779083269ab8064059808c70