### PR TITLE
Implement secure settings test endpoints and unlock secret editing

### DIFF
--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -9,9 +9,20 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Set
 from pydantic import BaseModel, Field
 
+try:  # Compatibilidad Pydantic v1/v2
+    from pydantic import ConfigDict  # type: ignore
+except Exception:  # pragma: no cover - ConfigDict no disponible en Pydantic v1
+    ConfigDict = None  # type: ignore
+
 
 class SettingsSchema(BaseModel):
     """Esquema de configuración completo"""
+
+    class Config:
+        extra = "allow"
+
+    if ConfigDict is not None:  # type: ignore[truthy-bool]
+        model_config = ConfigDict(extra="allow")  # type: ignore[misc]
     
     class NetworkSettings(BaseModel):
         openai_api_key: Optional[str] = None

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -347,34 +347,54 @@ class ApiService {
   }
 
   async updateBackendSettings(payload: BackendSettingsUpdate): Promise<BackendSettingsPayload> {
-    return apiWrapper.post<BackendSettingsPayload>('/api/settings', payload);
+    const { pin, ...rest } = payload;
+    const headers: Record<string, string> = {};
+    if (pin) {
+      headers.Authorization = `BasculaPin ${pin}`;
+    }
+
+    return apiWrapper.request<BackendSettingsPayload>('/api/settings', {
+      method: 'PUT',
+      body: rest,
+      headers,
+    });
   }
 
   async testOpenAI(apiKey?: string, pin?: string): Promise<IntegrationTestResponse> {
     const body: Record<string, string> = {};
     if (apiKey) {
-      body.apiKey = apiKey;
+      body.openai_api_key = apiKey;
     }
+    const headers: Record<string, string> = {};
     if (pin) {
-      body.pin = pin;
+      headers.Authorization = `BasculaPin ${pin}`;
     }
-    return apiWrapper.post<IntegrationTestResponse>('/api/settings/test/openai', body);
+
+    return apiWrapper.request<IntegrationTestResponse>('/api/settings/test/openai', {
+      method: 'POST',
+      body,
+      headers,
+    });
   }
 
   async testNightscout(url?: string, token?: string, pin?: string): Promise<IntegrationTestResponse> {
-    const params = new URLSearchParams();
+    const body: Record<string, string> = {};
     if (url) {
-      params.set('url', url);
+      body.nightscout_url = url;
     }
     if (token) {
-      params.set('token', token);
+      body.nightscout_token = token;
     }
+    const headers: Record<string, string> = {};
     if (pin) {
-      params.set('pin', pin);
+      headers.Authorization = `BasculaPin ${pin}`;
     }
-    const query = params.toString();
-    const endpoint = query ? `/api/nightscout/test?${query}` : '/api/nightscout/test';
-    return apiWrapper.get<IntegrationTestResponse>(endpoint);
+
+    return apiWrapper.request<IntegrationTestResponse>('/api/settings/test/nightscout', {
+      method: 'POST',
+      body,
+      headers,
+    });
   }
 
   // OTA Updates


### PR DESCRIPTION
## Summary
- require Bascula PIN headers for settings writes, add OpenAI/Nightscout test endpoints with rate limiting, and expose a settings health check
- reuse the settings service to hide stored secrets while preserving existing values when placeholders are submitted
- update the MiniWeb and kiosk settings UIs to enable editing secret fields after PIN verification, add visibility toggles, and call the new backend test endpoints

## Testing
- npm run lint *(fails: Unexpected any in useSettingsSync.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e48a495ba483269a2fbebf8a2735e5