### PR TITLE
Normalize settings payloads and relax PIN for loopback

### DIFF
--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -1,0 +1,113 @@
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+if "serial" not in sys.modules:
+    import types
+
+    serial_module = types.ModuleType("serial")
+
+    class SerialException(Exception):
+        pass
+
+    serial_module.SerialException = SerialException
+    serial_module.Serial = object  # type: ignore[attr-defined]
+    sys.modules["serial"] = serial_module
+
+from backend.app.services.settings_service import SettingsService
+from backend.main import (
+    _deep_merge_dict,
+    _normalize_settings_payload,
+    _synchronize_secret_aliases,
+    _SECRET_PLACEHOLDER,
+)
+
+
+@pytest.fixture()
+def settings_service(tmp_path: Path):
+    config_path = tmp_path / "config.json"
+    service = SettingsService(config_path)
+    return service, config_path
+
+
+def read_config(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def apply_updates(service: SettingsService, payload: dict) -> None:
+    existing = service.load().dict()
+    normalized = _normalize_settings_payload(payload, existing)
+    merged = deepcopy(existing)
+    _deep_merge_dict(merged, normalized)
+    _synchronize_secret_aliases(merged)
+    service._save_atomic(merged)
+
+
+def test_legacy_payload_is_normalized(settings_service):
+    service, config_path = settings_service
+
+    apply_updates(
+        service,
+        {
+            "openai": {"apiKey": "sk-test"},
+            "nightscout": {"url": "https://example.com", "token": "secret"},
+        },
+    )
+
+    config = read_config(config_path)
+    assert config.get("network", {}).get("openai_api_key") == "sk-test"
+    assert config.get("diabetes", {}).get("nightscout_url") == "https://example.com"
+    assert config.get("diabetes", {}).get("nightscout_token") == "secret"
+
+
+def test_placeholder_keeps_existing_secret(settings_service):
+    service, config_path = settings_service
+
+    apply_updates(
+        service,
+        {
+            "network": {"openai_api_key": "sk-live"},
+            "diabetes": {"nightscout_url": "https://ns.example", "nightscout_token": "tok"},
+        },
+    )
+
+    apply_updates(
+        service,
+        {
+            "network": {"openai_api_key": _SECRET_PLACEHOLDER},
+            "diabetes": {
+                "nightscout_url": _SECRET_PLACEHOLDER,
+                "nightscout_token": _SECRET_PLACEHOLDER,
+            },
+        },
+    )
+
+    config = read_config(config_path)
+    assert config.get("network", {}).get("openai_api_key") == "sk-live"
+    assert config.get("diabetes", {}).get("nightscout_url") == "https://ns.example"
+    assert config.get("diabetes", {}).get("nightscout_token") == "tok"
+
+
+def test_get_masks_secret_values(settings_service):
+    service, _ = settings_service
+
+    apply_updates(
+        service,
+        {
+            "network": {"openai_api_key": "sk-mask"},
+            "diabetes": {"nightscout_url": "https://mask", "nightscout_token": "hidden"},
+        },
+    )
+
+    payload = service.get_for_client(include_secrets=False)
+    assert payload.get("network", {}).get("openai_api_key") == _SECRET_PLACEHOLDER
+    assert payload.get("diabetes", {}).get("nightscout_url") == _SECRET_PLACEHOLDER
+    assert payload.get("diabetes", {}).get("nightscout_token") == _SECRET_PLACEHOLDER

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -103,22 +103,27 @@ export interface BackendSettingsPayload {
   tts?: Record<string, unknown>;
   scale?: Record<string, unknown>;
   serial?: { device?: string; baud?: number };
-  network?: { status?: BackendWifiStatus | null; ap?: { ssid: string; ip: string } };
-  openai?: { hasKey?: boolean };
-  nightscout?: { url?: string; hasToken?: boolean };
+  network?: {
+    status?: BackendWifiStatus | null;
+    ap?: { ssid: string; ip: string };
+    openai_api_key?: string | null;
+  };
+  diabetes?: {
+    nightscout_url?: string | null;
+    nightscout_token?: string | null;
+  };
   integrations?: Record<string, unknown>;
 }
 
 export interface BackendSettingsUpdate {
   pin?: string;
-  openai?: { apiKey?: string | null };
-  nightscout?: { url?: string | null; token?: string | null };
+  network?: { openai_api_key?: string | null } & Record<string, unknown>;
+  diabetes?: { nightscout_url?: string | null; nightscout_token?: string | null } & Record<string, unknown>;
   ui?: Record<string, unknown>;
   tts?: Record<string, unknown>;
   scale?: Record<string, unknown>;
   serial?: Record<string, unknown>;
   integrations?: Record<string, unknown>;
-  network?: Record<string, unknown>;
 }
 
 export interface IntegrationTestResponse {


### PR DESCRIPTION
## Summary
- normalize settings payloads on the backend, preserve stored secrets, extend health/test endpoints, and skip PIN for loopback clients
- align frontend API usage and configuration screens with the new network/diabetes settings keys while keeping remote inputs editable
- add backend tests covering legacy payloads, placeholder handling, and secret masking in settings responses

## Testing
- pytest backend/tests/test_settings_api.py
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e49470fcc8832692ffa2b24ad328cf