### PR TITLE
Set UI sound default to enabled

### DIFF
--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -39,7 +39,7 @@ class SettingsSchema(BaseModel):
         hyper_alarm: float = 180.0
     
     class UiSettings(BaseModel):
-        sound_enabled: bool = False
+        sound_enabled: bool = True
         flags: Dict[str, bool] = Field(default_factory=dict)
     
     class ScaleSettings(BaseModel):

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -111,3 +111,26 @@ def test_get_masks_secret_values(settings_service):
     assert payload.get("network", {}).get("openai_api_key") == _SECRET_PLACEHOLDER
     assert payload.get("diabetes", {}).get("nightscout_url") == _SECRET_PLACEHOLDER
     assert payload.get("diabetes", {}).get("nightscout_token") == _SECRET_PLACEHOLDER
+
+
+def test_default_sound_enabled_is_true(settings_service):
+    service, _ = settings_service
+
+    settings = service.load()
+
+    assert settings.ui.sound_enabled is True
+
+
+def test_sound_enabled_respects_saved_value(settings_service):
+    service, _ = settings_service
+
+    apply_updates(
+        service,
+        {
+            "ui": {"sound_enabled": False},
+        },
+    )
+
+    settings = service.load()
+
+    assert settings.ui.sound_enabled is False


### PR DESCRIPTION
## Summary
- set the default `ui.sound_enabled` flag to true when loading settings without a stored value
- add regression tests covering the default state and persistence of saved sound preferences

## Testing
- pytest backend/tests/test_settings_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e4ce6d11648326811646218b5b4089