### PR TITLE
Add offline mode routing and remote configuration updates

### DIFF
--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -41,6 +41,7 @@ class SettingsSchema(BaseModel):
     class UiSettings(BaseModel):
         sound_enabled: bool = True
         flags: Dict[str, bool] = Field(default_factory=dict)
+        offline_mode: bool = False
     
     class ScaleSettings(BaseModel):
         calibration_factor: float = 1.0

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,10 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import OfflineMode from "./pages/OfflineMode";
 import NotFound from "./pages/NotFound";
 import { MiniWebConfig } from "./pages/MiniWebConfig";
+import { APModeScreen } from "@/components/APModeScreen";
 
 const queryClient = new QueryClient();
 
@@ -22,7 +24,9 @@ const App = () => (
       >
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/ap" element={<APModeScreen />} />
           <Route path="/config" element={<MiniWebConfig />} />
+          <Route path="/offline" element={<OfflineMode />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -102,7 +102,14 @@ const Index = () => {
 
       const previous = previousNetworkStatus.current;
 
-      if (status.showAPScreen) {
+      if (status.offlineModeEnabled && !status.hasInternet && status.effectiveMode === "offline") {
+        setNetworkNotice({
+          message: "Modo offline: sin conexión a Internet",
+          type: "warning",
+        });
+        setBasculinMood("worried");
+        setMascoMsg("Modo offline activo");
+      } else if (status.showAPScreen) {
         setNetworkNotice({
           message: "Modo punto de acceso activo para provisión de Wi-Fi",
           type: "info",
@@ -517,6 +524,15 @@ const Index = () => {
           <div className="flex items-center gap-2 rounded-full border border-primary/40 bg-background/95 px-5 py-2 text-sm font-medium text-primary shadow-lg">
             <span className="animate-pulse">🎤</span>
             <span>Te escucho…</span>
+          </div>
+        </div>
+      )}
+
+      {networkStatusState?.offlineModeEnabled && !networkStatusState?.hasInternet && (
+        <div className="pointer-events-none fixed right-4 top-4 z-40">
+          <div className="flex items-center gap-2 rounded-full border border-amber-400/70 bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-200 shadow-lg backdrop-blur">
+            <span className="h-2 w-2 rounded-full bg-amber-400 animate-pulse" />
+            Offline
           </div>
         </div>
       )}

--- a/src/pages/OfflineMode.tsx
+++ b/src/pages/OfflineMode.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { AlertCircle, Clock, Scale, WifiOff, Settings2 } from "lucide-react";
+
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useScaleWebSocket } from "@/hooks/useScaleWebSocket";
+import { useScaleDecimals } from "@/hooks/useScaleDecimals";
+import { formatWeight } from "@/lib/format";
+import { api } from "@/services/api";
+
+const formatSeconds = (totalSeconds: number): string => {
+  const safeSeconds = Math.max(0, Math.floor(totalSeconds));
+  const minutes = Math.floor(safeSeconds / 60)
+    .toString()
+    .padStart(2, "0");
+  const seconds = (safeSeconds % 60).toString().padStart(2, "0");
+  return `${minutes}:${seconds}`;
+};
+
+const buildConfigUrl = (): string => {
+  if (typeof window === "undefined" || !window.location?.origin) {
+    return "http://192.168.4.1/config";
+  }
+  const origin = window.location.origin.replace(/\/+$/, "");
+  return `${origin}/config`;
+};
+
+const OfflineMode = () => {
+  const { weight, isStable, unit, isConnected } = useScaleWebSocket();
+  const decimals = useScaleDecimals();
+  const [displayUnit, setDisplayUnit] = useState<"g" | "ml">("g");
+  const [timerMinutes, setTimerMinutes] = useState(5);
+  const [timerRunning, setTimerRunning] = useState(false);
+  const [timerRemaining, setTimerRemaining] = useState(0);
+  const [updatingTimer, setUpdatingTimer] = useState(false);
+
+  const displayedWeight = useMemo(() => {
+    if (displayUnit === "ml" && unit === "g") {
+      return weight;
+    }
+    return weight;
+  }, [displayUnit, unit, weight]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const status = await api.getTimerStatus();
+        if (cancelled) {
+          return;
+        }
+        setTimerRunning(status.running);
+        setTimerRemaining(status.remaining ?? 0);
+      } catch (error) {
+        if (!cancelled) {
+          setTimerRunning(false);
+          setTimerRemaining(0);
+        }
+      }
+    };
+
+    void poll();
+    const interval = window.setInterval(() => {
+      void poll();
+    }, 1000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  const handleToggleUnit = () => {
+    setDisplayUnit((prev) => (prev === "g" ? "ml" : "g"));
+    if (navigator.vibrate) {
+      navigator.vibrate(30);
+    }
+  };
+
+  const handleTare = async () => {
+    try {
+      await api.scaleTare();
+    } catch (error) {
+      console.warn("No se pudo aplicar la tara en modo offline", error);
+    }
+  };
+
+  const handleStartTimer = async (minutes: number) => {
+    const normalizedMinutes = Number.isFinite(minutes) ? Math.max(0.1, minutes) : 1;
+    const seconds = Math.round(normalizedMinutes * 60);
+    setUpdatingTimer(true);
+    try {
+      await api.startTimer(seconds);
+      setTimerRunning(true);
+      setTimerRemaining(seconds);
+      setTimerMinutes(normalizedMinutes);
+    } catch (error) {
+      console.warn("No se pudo iniciar el temporizador en modo offline", error);
+    } finally {
+      setUpdatingTimer(false);
+    }
+  };
+
+  const handleStopTimer = async () => {
+    setUpdatingTimer(true);
+    try {
+      await api.stopTimer();
+      setTimerRunning(false);
+      setTimerRemaining(0);
+    } catch (error) {
+      console.warn("No se pudo detener el temporizador en modo offline", error);
+    } finally {
+      setUpdatingTimer(false);
+    }
+  };
+
+  const configUrl = buildConfigUrl();
+
+  return (
+    <div className="min-h-screen bg-background px-4 py-8">
+      <div className="mx-auto flex max-w-4xl flex-col gap-6">
+        <Card className="border-amber-300/30 bg-amber-500/5 p-6 text-amber-100">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div className="flex items-start gap-3">
+              <div className="rounded-full bg-amber-500/20 p-2">
+                <WifiOff className="h-6 w-6" />
+              </div>
+              <div className="space-y-1">
+                <p className="text-lg font-semibold">Modo offline activado</p>
+                <p className="text-sm text-amber-100/80">
+                  Sin conexión a Internet. Puedes pesar y usar el temporizador; las funciones de IA y Nightscout están
+                  desactivadas.
+                </p>
+                <p className="text-sm text-amber-100/70">
+                  Configura la red desde otro dispositivo entrando en <span className="font-semibold">{configUrl}</span>.
+                </p>
+              </div>
+            </div>
+            <Button variant="outline" className="border-amber-300 text-amber-100 hover:bg-amber-500/20" asChild>
+              <Link to="/config">
+                <Settings2 className="mr-2 h-4 w-4" /> Abrir configuración
+              </Link>
+            </Button>
+          </div>
+        </Card>
+
+        <div className="grid gap-6 md:grid-cols-2">
+          <Card className="border-primary/30 bg-background/60 p-6 shadow-lg">
+            <div className="mb-4 flex items-center justify-between">
+              <div className="flex items-center gap-2 text-lg font-semibold">
+                <Scale className="h-5 w-5 text-primary" /> Peso actual
+              </div>
+              <span className="rounded-full border border-primary/40 px-3 py-1 text-xs font-medium uppercase tracking-wide text-primary">
+                {isConnected ? "Conectado" : "Sin datos"}
+              </span>
+            </div>
+            <div className="flex flex-col items-center gap-4">
+              <div className={`text-7xl font-bold tracking-tight ${isStable ? "text-primary" : "text-muted-foreground"}`}>
+                {formatWeight(displayedWeight ?? 0, decimals)}
+              </div>
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <span className={`h-2 w-2 rounded-full ${isStable ? "bg-primary" : "bg-muted-foreground animate-pulse"}`} />
+                {isStable ? "Peso estable" : "Estabilizando…"}
+              </div>
+              <div className="flex gap-3">
+                <Button variant="outline" onClick={handleTare} disabled={!isConnected}>
+                  Tara
+                </Button>
+                <Button variant="ghost" onClick={handleToggleUnit}>
+                  Cambiar a {displayUnit === "g" ? "ml" : "g"}
+                </Button>
+              </div>
+            </div>
+          </Card>
+
+          <Card className="border-primary/30 bg-background/60 p-6 shadow-lg">
+            <div className="mb-4 flex items-center justify-between">
+              <div className="flex items-center gap-2 text-lg font-semibold">
+                <Clock className="h-5 w-5 text-primary" /> Temporizador
+              </div>
+              <span className="text-sm text-muted-foreground">
+                {timerRunning ? "En marcha" : "Detenido"}
+              </span>
+            </div>
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col items-center gap-2">
+                <div className="text-5xl font-bold text-primary">{formatSeconds(timerRemaining)}</div>
+                <p className="text-xs text-muted-foreground">
+                  El temporizador funciona sin conexión para recordatorios básicos.
+                </p>
+              </div>
+              <div className="grid gap-3 md:grid-cols-2">
+                {[1, 3, 5].map((preset) => (
+                  <Button
+                    key={preset}
+                    variant="outline"
+                    onClick={() => void handleStartTimer(preset)}
+                    disabled={updatingTimer}
+                  >
+                    {preset} min
+                  </Button>
+                ))}
+              </div>
+              <div className="flex items-center gap-3">
+                <Input
+                  type="number"
+                  min={0.1}
+                  step={0.5}
+                  value={timerMinutes}
+                  onChange={(event) => setTimerMinutes(Number(event.target.value))}
+                  className="flex-1"
+                />
+                <Button
+                  variant="glow"
+                  onClick={() => void handleStartTimer(timerMinutes)}
+                  disabled={updatingTimer}
+                >
+                  Iniciar
+                </Button>
+                <Button variant="outline" onClick={() => void handleStopTimer()} disabled={updatingTimer || !timerRunning}>
+                  Detener
+                </Button>
+              </div>
+            </div>
+          </Card>
+        </div>
+
+        <Card className="border-border/60 bg-muted/20 p-5 text-sm text-muted-foreground">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="mt-0.5 h-4 w-4 text-muted-foreground" />
+            <div>
+              <p>
+                Cuando recuperes la conexión a Internet podrás volver a usar las funciones inteligentes desde la opción de
+                configuración.
+              </p>
+            </div>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default OfflineMode;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -99,7 +99,7 @@ export interface BackendNetworkStatus {
 }
 
 export interface BackendSettingsPayload {
-  ui?: { flags?: Record<string, boolean> };
+  ui?: { flags?: Record<string, boolean>; offline_mode?: boolean };
   tts?: Record<string, unknown>;
   scale?: Record<string, unknown>;
   serial?: { device?: string; baud?: number };
@@ -119,7 +119,7 @@ export interface BackendSettingsUpdate {
   pin?: string;
   network?: { openai_api_key?: string | null } & Record<string, unknown>;
   diabetes?: { nightscout_url?: string | null; nightscout_token?: string | null } & Record<string, unknown>;
-  ui?: Record<string, unknown>;
+  ui?: ({ flags?: Record<string, boolean>; offline_mode?: boolean | number | string } & Record<string, unknown>) | undefined;
   tts?: Record<string, unknown>;
   scale?: Record<string, unknown>;
   serial?: Record<string, unknown>;
@@ -166,7 +166,9 @@ export interface WakeEvent {
 
 export type MiniwebStatus = {
   ok: boolean;
-  mode: "ap" | "kiosk";
+  mode: "ap" | "kiosk" | "offline";
+  effective_mode?: "ap" | "kiosk" | "offline";
+  offline_mode?: boolean;
   wifi: {
     connected: boolean;
     ssid?: string | null;
@@ -177,6 +179,8 @@ export type MiniwebStatus = {
   ssid?: string | null;
   ip?: string | null;
   ip_address?: string | null;
+  ethernet_connected?: boolean;
+  internet?: boolean;
 } & Record<string, unknown>;
 
 class ApiService {

--- a/src/services/networkDetector.ts
+++ b/src/services/networkDetector.ts
@@ -5,10 +5,14 @@ import { logger } from './logger';
 export interface NetworkStatus {
   isOnline: boolean;
   isWifiConnected: boolean;
+  ethernetConnected: boolean;
   apActive: boolean;
   connectivity: 'full' | 'limited' | 'portal' | 'none' | 'unknown';
   savedWifiProfiles: boolean;
   showAPScreen: boolean;
+  offlineModeEnabled: boolean;
+  effectiveMode: 'ap' | 'kiosk' | 'offline' | 'unknown';
+  hasInternet: boolean;
   ssid?: string;
   ip?: string;
 }
@@ -19,11 +23,16 @@ class NetworkDetector {
   private currentStatus: NetworkStatus = {
     isOnline: navigator.onLine,
     isWifiConnected: false,
+    ethernetConnected: false,
     apActive: false,
     connectivity: 'unknown',
     savedWifiProfiles: false,
     showAPScreen: false,
+    offlineModeEnabled: false,
+    effectiveMode: 'unknown',
+    hasInternet: false,
   };
+  private eventSource: EventSource | null = null;
 
   constructor() {
     this.setupListeners();
@@ -42,6 +51,34 @@ class NetworkDetector {
     });
   }
 
+  private setupEventStream() {
+    if (this.eventSource || typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const source = new EventSource('/api/net/events');
+      source.addEventListener('status', () => {
+        void this.checkNetworkStatus();
+      });
+      source.addEventListener('wifi_connected', () => {
+        void this.checkNetworkStatus();
+      });
+      source.addEventListener('wifi_failed', () => {
+        void this.checkNetworkStatus();
+      });
+      source.onerror = (event) => {
+        logger.debug('NetworkDetector SSE reported an error', { event });
+        source.close();
+        this.eventSource = null;
+        setTimeout(() => this.setupEventStream(), 5000);
+      };
+      this.eventSource = source;
+    } catch (error) {
+      logger.warn('Unable to open network status stream', { error });
+    }
+  }
+
   private async checkNetworkStatus(): Promise<NetworkStatus> {
     const isOnline = navigator.onLine;
 
@@ -53,6 +90,10 @@ class NetworkDetector {
     let connectivity: NetworkStatus['connectivity'] = this.currentStatus.connectivity;
     let savedWifiProfiles = this.currentStatus.savedWifiProfiles;
     let showAPScreen = this.currentStatus.showAPScreen;
+    let ethernetConnected = this.currentStatus.ethernetConnected;
+    let offlineModeEnabled = this.currentStatus.offlineModeEnabled;
+    let effectiveMode = this.currentStatus.effectiveMode;
+    let hasInternet = this.currentStatus.hasInternet;
 
     if (isOnline) {
       try {
@@ -64,8 +105,12 @@ class NetworkDetector {
 
         if (response.ok) {
           const data = await response.json();
-          ssid = typeof data.ssid === 'string' ? data.ssid : undefined;
-          ip = typeof data.ip === 'string' ? data.ip : undefined;
+          ssid = typeof data.ssid === 'string' && data.ssid ? data.ssid : undefined;
+          if (typeof data.ip === 'string' && data.ip) {
+            ip = data.ip;
+          } else if (typeof data.ip_address === 'string' && data.ip_address) {
+            ip = data.ip_address;
+          }
 
           const connectivityValue = typeof data.connectivity === 'string' ? data.connectivity.toLowerCase() : 'unknown';
           if (connectivityValue === 'full' || connectivityValue === 'limited' || connectivityValue === 'portal' || connectivityValue === 'none') {
@@ -76,7 +121,28 @@ class NetworkDetector {
           savedWifiProfiles = data.saved_wifi_profiles === true;
           const connectedField = typeof data.connected === 'boolean' ? data.connected : undefined;
           isWifiConnected = connectedField ?? connectivity === 'full';
-          showAPScreen = apActive;
+
+          if (data.wifi && typeof data.wifi === 'object') {
+            const wifiData = data.wifi as Record<string, unknown>;
+            if (typeof wifiData.connected === 'boolean') {
+              isWifiConnected = wifiData.connected;
+            }
+            if (!ip && typeof wifiData.ip === 'string' && wifiData.ip.trim()) {
+              ip = wifiData.ip.trim();
+            }
+          }
+
+          offlineModeEnabled = data.offline_mode === true;
+          ethernetConnected = data.ethernet_connected === true;
+          const effectiveModeRaw =
+            typeof data.effective_mode === 'string' ? data.effective_mode.trim().toLowerCase() : '';
+          if (effectiveModeRaw === 'ap' || effectiveModeRaw === 'kiosk' || effectiveModeRaw === 'offline') {
+            effectiveMode = effectiveModeRaw;
+          } else {
+            effectiveMode = 'unknown';
+          }
+          hasInternet = data.internet === true || connectivity === 'full';
+          showAPScreen = effectiveMode === 'ap';
 
           logger.info('Network status fetched', {
             connectivity,
@@ -85,6 +151,9 @@ class NetworkDetector {
             isWifiConnected,
             ssid,
             ip,
+            ethernetConnected,
+            offlineModeEnabled,
+            effectiveMode,
           });
         }
       } catch (error) {
@@ -92,15 +161,20 @@ class NetworkDetector {
       }
     } else {
       showAPScreen = apActive;
+      hasInternet = false;
     }
 
     const status: NetworkStatus = {
       isOnline,
       isWifiConnected,
+      ethernetConnected,
       apActive,
       connectivity,
       savedWifiProfiles,
       showAPScreen,
+      offlineModeEnabled,
+      effectiveMode,
+      hasInternet,
       ssid,
       ip,
     };
@@ -131,7 +205,9 @@ class NetworkDetector {
     }
 
     logger.info('Starting network monitoring', { intervalMs });
-    
+
+    this.setupEventStream();
+
     // Check immediately
     this.checkNetworkStatus();
 
@@ -146,6 +222,10 @@ class NetworkDetector {
       clearInterval(this.checkInterval);
       this.checkInterval = null;
       logger.info('Network monitoring stopped');
+    }
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
     }
   }
 


### PR DESCRIPTION
## Summary
- expose offline mode and effective kiosk mode from the backend status/settings APIs and propagate through SSE updates
- launch the kiosk UI directly into /, /ap, or /offline based on effective mode while keeping AP flow informative
- refresh the React app with dedicated /offline and /ap routes, offline badge, configuration messaging, and a full offline weighing/timer screen with copy/paste friendly inputs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e519c92e788326b9b791a77caf8e88