### PR TITLE
Fix offline effective mode and launcher behavior

### DIFF
--- a/backend/tests/test_effective_mode.py
+++ b/backend/tests/test_effective_mode.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from backend.miniweb import _determine_effective_mode
+
+
+@pytest.mark.parametrize(
+    "ethernet_connected,wifi_connected,internet_available,offline_mode_enabled,expected",
+    [
+        (True, False, False, True, "offline"),
+        (True, False, True, True, "kiosk"),
+        (True, False, True, False, "kiosk"),
+        (False, True, False, True, "offline"),
+        (False, True, False, False, "kiosk"),
+        (False, True, True, True, "kiosk"),
+        (False, True, True, False, "kiosk"),
+        (False, False, False, True, "offline"),
+        (False, False, False, False, "ap"),
+    ],
+)
+def test_determine_effective_mode(
+    ethernet_connected: bool,
+    wifi_connected: bool,
+    internet_available: bool,
+    offline_mode_enabled: bool,
+    expected: str,
+) -> None:
+    assert (
+        _determine_effective_mode(
+            ethernet_connected=ethernet_connected,
+            wifi_connected=wifi_connected,
+            offline_mode_enabled=offline_mode_enabled,
+            internet_available=internet_available,
+        )
+        == expected
+    )

--- a/backend/tests/test_kiosk_launcher.py
+++ b/backend/tests/test_kiosk_launcher.py
@@ -1,0 +1,35 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.choose_kiosk_target import determine_target_url, main as choose_main
+
+
+@pytest.mark.parametrize(
+    "mode,expected",
+    [
+        ("kiosk", "http://localhost/"),
+        ("offline", "http://localhost/offline"),
+        ("ap", "http://localhost/ap"),
+        ("unknown", "http://localhost/"),
+        ("", "http://localhost/"),
+    ],
+)
+def test_determine_target_url(mode: str, expected: str) -> None:
+    assert determine_target_url({"effective_mode": mode}) == expected
+
+
+def test_main_uses_mock_status(monkeypatch, capsys):
+    payload = {"effective_mode": "offline"}
+    monkeypatch.setenv("BASCULA_KIOSK_STATUS_JSON", json.dumps(payload))
+
+    exit_code = choose_main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip() == "ready|http://localhost/offline"

--- a/scripts/choose_kiosk_target.py
+++ b/scripts/choose_kiosk_target.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Helper used by the kiosk launcher to determine which URL should be opened."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Mapping, Optional
+
+HEALTH_URL = os.environ.get("BASCULA_KIOSK_HEALTH_URL", "http://127.0.0.1:8080/health")
+STATUS_URL = os.environ.get(
+    "BASCULA_KIOSK_STATUS_URL", "http://127.0.0.1:8080/api/miniweb/status"
+)
+MODE_TARGETS: Mapping[str, str] = {
+    "kiosk": "http://localhost/",
+    "ap": "http://localhost/ap",
+    "offline": "http://localhost/offline",
+}
+DEFAULT_TARGET = MODE_TARGETS["kiosk"]
+FALLBACK_TARGET = "http://localhost/config"
+
+
+def determine_target_url(data: Mapping[str, Any]) -> str:
+    """Return the launcher URL for the provided status payload."""
+
+    raw_mode = str(data.get("effective_mode") or data.get("mode") or "").strip().lower()
+    return MODE_TARGETS.get(raw_mode, DEFAULT_TARGET)
+
+
+def _load_mock_status() -> Optional[Mapping[str, Any]]:
+    raw = os.environ.get("BASCULA_KIOSK_STATUS_JSON")
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(data, Mapping):
+        return data
+    return None
+
+
+def _wait_for_health(timeout: float = 15.0) -> bool:
+    if os.environ.get("BASCULA_KIOSK_STATUS_JSON"):
+        return True
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(HEALTH_URL, timeout=2) as response:  # noqa: S310
+                status = getattr(response, "status", 200)
+                if 200 <= status < 500:
+                    return True
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError):
+            time.sleep(1)
+        except Exception:
+            time.sleep(1)
+    return False
+
+
+def _fetch_status(timeout: float = 5.0) -> Optional[Mapping[str, Any]]:
+    mock = _load_mock_status()
+    if mock is not None:
+        return mock
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(STATUS_URL, timeout=2) as response:  # noqa: S310
+                return json.load(response)
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, json.JSONDecodeError):
+            time.sleep(1)
+        except Exception:
+            time.sleep(1)
+    return None
+
+
+def main() -> int:
+    if _wait_for_health():
+        status = _fetch_status()
+        if isinstance(status, Mapping):
+            target = determine_target_url(status)
+            print(f"ready|{target}")
+            return 0
+    print(f"fallback|{FALLBACK_TARGET}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/start-kiosk.sh
+++ b/scripts/start-kiosk.sh
@@ -24,6 +24,8 @@ trap cleanup_background EXIT
 
 log "Iniciando sesión de kiosk (replace=${BASCULA_KIOSK_REPLACE_WM:-0})"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 if command -v xset >/dev/null 2>&1; then
   xset s off || true
   xset -dpms || true
@@ -57,77 +59,10 @@ sleep 1
 
 BACKEND_RESULT=""
 set +e
-BACKEND_RESULT=$(python3 <<'PY'
-import json
-import time
-import urllib.error
-import urllib.request
-
-HEALTH_URL = "http://127.0.0.1:8080/health"
-STATUS_URL = "http://127.0.0.1:8080/api/miniweb/status"
-
-
-def wait_for_health(timeout: float = 15.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            with urllib.request.urlopen(HEALTH_URL, timeout=2) as response:
-                if 200 <= getattr(response, "status", 200) < 500:
-                    return True
-        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError):
-            time.sleep(1)
-            continue
-        except Exception:
-            time.sleep(1)
-            continue
-    return False
-
-
-def choose_target(timeout: float = 5.0) -> str:
-    deadline = time.monotonic() + timeout
-    last_ethernet = False
-    offline_mode = False
-    while time.monotonic() < deadline:
-        try:
-            with urllib.request.urlopen(STATUS_URL, timeout=2) as response:
-                data = json.load(response)
-        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, json.JSONDecodeError):
-            time.sleep(1)
-            continue
-        except Exception:
-            time.sleep(1)
-            continue
-
-        effective_mode = str(data.get("effective_mode") or data.get("mode") or "").lower()
-        offline_mode = bool(data.get("offline_mode"))
-        wifi = data.get("wifi") or {}
-        wifi_connected = bool(wifi.get("connected"))
-        wifi_ip = wifi.get("ip") or data.get("ip") or data.get("ip_address")
-        ethernet_connected = bool(data.get("ethernet_connected"))
-        last_ethernet = ethernet_connected
-
-        if effective_mode == "kiosk" or (wifi_connected and wifi_ip) or ethernet_connected:
-            return "http://localhost/"
-        if effective_mode == "offline" or (offline_mode and not wifi_connected and not ethernet_connected):
-            return "http://localhost/offline"
-        if effective_mode == "ap":
-            return "http://localhost/ap"
-    if last_ethernet:
-        return "http://localhost/"
-    if offline_mode:
-        return "http://localhost/offline"
-    return "http://localhost/ap"
-
-if wait_for_health():
-    target = choose_target()
-    print(f"ready|{target}")
-else:
-    print("fallback|http://localhost/config")
-PY
-)
+BACKEND_RESULT=$(python3 "${SCRIPT_DIR}/choose_kiosk_target.py")
 PY_STATUS=$?
 set -e
-if [[ ${PY_STATUS} -ne 0 ]]; then
+if [[ ${PY_STATUS} -ne 0 || -z "${BACKEND_RESULT}" ]]; then
   BACKEND_RESULT="fallback|http://localhost/config"
 fi
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -102,7 +102,7 @@ const Index = () => {
 
       const previous = previousNetworkStatus.current;
 
-      if (status.offlineModeEnabled && !status.hasInternet && status.effectiveMode === "offline") {
+      if (status.effectiveMode === "offline") {
         setNetworkNotice({
           message: "Modo offline: sin conexión a Internet",
           type: "warning",
@@ -528,7 +528,7 @@ const Index = () => {
         </div>
       )}
 
-      {networkStatusState?.offlineModeEnabled && !networkStatusState?.hasInternet && (
+      {networkStatusState?.effectiveMode === "offline" && (
         <div className="pointer-events-none fixed right-4 top-4 z-40">
           <div className="flex items-center gap-2 rounded-full border border-amber-400/70 bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-200 shadow-lg backdrop-blur">
             <span className="h-2 w-2 rounded-full bg-amber-400 animate-pulse" />

--- a/src/pages/MiniWebConfig.tsx
+++ b/src/pages/MiniWebConfig.tsx
@@ -1031,7 +1031,7 @@ export const MiniWebConfig = () => {
     if (!networkStatus) {
       return "Desconocido";
     }
-    if (networkStatus.effectiveMode === "offline" || (networkStatus.offlineMode && !networkStatus.hasInternet)) {
+    if (networkStatus.effectiveMode === "offline") {
       return "Modo offline";
     }
     if (networkStatus.apActive) {

--- a/tests/offline-mode-ui.test.tsx
+++ b/tests/offline-mode-ui.test.tsx
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+
+vi.mock('@/components/MainMenu', () => ({ MainMenu: () => <div data-testid="main-menu" /> }));
+vi.mock('@/pages/ScaleView', () => ({ ScaleView: () => <div data-testid="scale-view" /> }));
+vi.mock('@/pages/FoodScannerView', () => ({ FoodScannerView: () => <div data-testid="scanner-view" /> }));
+vi.mock('@/pages/TimerFullView', () => ({ TimerFullView: () => <div data-testid="timer-view" /> }));
+vi.mock('@/pages/RecipesView', () => ({ RecipesView: () => <div data-testid="recipes-view" /> }));
+vi.mock('@/pages/SettingsView', () => ({ SettingsView: () => <div data-testid="settings-view" /> }));
+vi.mock('@/components/TopBar', () => ({ TopBar: () => <div data-testid="top-bar" /> }));
+vi.mock('@/components/NotificationBar', () => ({
+  NotificationBar: ({ message }: { message: string }) => (
+    <div data-testid="notification">{message}</div>
+  ),
+}));
+vi.mock('@/components/TimerDialog', () => ({ TimerDialog: () => null }));
+vi.mock('@/components/Mode1515Dialog', () => ({ Mode1515Dialog: () => null }));
+vi.mock('@/components/RecoveryMode', () => ({ RecoveryMode: () => <div>Recovery</div> }));
+vi.mock('@/components/APModeScreen', () => ({ APModeScreen: () => <div>AP Mode</div> }));
+vi.mock('@/components/BasculinMascot', () => ({ BasculinMascot: () => <div data-testid="mascot" /> }));
+vi.mock('@/hooks/useGlucoseMonitor', () => ({ useGlucoseMonitor: () => null }));
+vi.mock('@/services/api', () => ({
+  api: {
+    startTimer: vi.fn(() => Promise.resolve()),
+    getScaleWeight: vi.fn(() => Promise.resolve({ value: 0 })),
+    scaleTare: vi.fn(() => Promise.resolve()),
+    getWakeStatus: vi.fn(() => Promise.resolve({ enabled: false, running: false })),
+  },
+}));
+vi.mock('@/services/apiWrapper', () => ({
+  apiWrapper: {
+    getBaseUrl: vi.fn(() => 'http://localhost'),
+  },
+}));
+vi.mock('@/services/storage', () => ({
+  storage: {
+    getSettings: vi.fn(() => ({ wakeWordEnabled: false, apiUrl: 'http://localhost' })),
+    setSettings: vi.fn(),
+  },
+}));
+vi.mock('@/lib/format', () => ({ formatWeight: (value: number) => value.toString() }));
+vi.mock('@/hooks/useScaleDecimals', () => ({ useScaleDecimals: () => 1 }));
+
+const baseStatus = {
+  isOnline: true,
+  isWifiConnected: true,
+  ethernetConnected: false,
+  apActive: false,
+  connectivity: 'full' as const,
+  savedWifiProfiles: true,
+  showAPScreen: false,
+  offlineModeEnabled: false,
+  effectiveMode: 'kiosk' as const,
+  hasInternet: true,
+  ssid: 'TestWifi',
+  ip: '192.168.1.10',
+};
+
+const listeners: ((status: typeof baseStatus) => void)[] = [];
+let currentStatus = { ...baseStatus };
+
+const emitStatus = () => {
+  for (const listener of listeners) {
+    listener({ ...currentStatus });
+  }
+};
+
+vi.mock('@/services/networkDetector', () => ({
+  networkDetector: {
+    subscribe: vi.fn((listener: (status: typeof baseStatus) => void) => {
+      listeners.push(listener);
+      listener({ ...currentStatus });
+    }),
+    unsubscribe: vi.fn((listener: (status: typeof baseStatus) => void) => {
+      const index = listeners.indexOf(listener);
+      if (index >= 0) {
+        listeners.splice(index, 1);
+      }
+    }),
+    startMonitoring: vi.fn(),
+    stopMonitoring: vi.fn(),
+    getCurrentStatus: vi.fn(() => ({ ...currentStatus })),
+    __setStatus: (status: Partial<typeof baseStatus>) => {
+      currentStatus = { ...currentStatus, ...status };
+      emitStatus();
+    },
+    __reset: () => {
+      currentStatus = { ...baseStatus };
+    },
+  },
+}));
+
+import Index from '@/pages/Index';
+import App from '@/App';
+import { networkDetector } from '@/services/networkDetector';
+
+const mockedDetector = networkDetector as unknown as {
+  __setStatus: (status: Partial<typeof baseStatus>) => void;
+  __reset: () => void;
+};
+
+describe('Offline mode experience', () => {
+  beforeEach(() => {
+    listeners.length = 0;
+    mockedDetector.__reset();
+  });
+
+  it('shows an Offline badge on the main view when effective mode is offline', async () => {
+    render(
+      <MemoryRouter>
+        <Index />
+      </MemoryRouter>,
+    );
+
+    await act(async () => {
+      mockedDetector.__setStatus({ effectiveMode: 'offline', offlineModeEnabled: true, hasInternet: false });
+    });
+
+    expect(await screen.findByText('Offline')).toBeInTheDocument();
+  });
+
+  it('renders the offline page when navigating to /offline', () => {
+    window.history.pushState({}, '', '/offline');
+
+    render(<App />);
+
+    expect(screen.getByText('Modo offline activado')).toBeInTheDocument();
+
+    window.history.pushState({}, '', '/');
+  });
+});


### PR DESCRIPTION
## Summary
- update the miniweb effective mode calculation to honor offline mode when there is LAN connectivity and keep the AP disabled when Ethernet or Wi-Fi are present
- extract the launcher targeting logic into a Python helper that reads effective_mode and simplify the kiosk shell script to use it
- surface offline state in the React UI and add focused backend, launcher, and UI tests for offline scenarios

## Testing
- pytest backend/tests
- npm test -- --run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68e52689634883268c54e1bf939f18eb