### PR TITLE
Fix offline mode detection and AP provisioning flow

### DIFF
--- a/backend/miniweb.py
+++ b/backend/miniweb.py
@@ -3061,12 +3061,13 @@ def _determine_effective_mode(
     offline_mode_enabled: bool,
     internet_available: bool,
 ) -> str:
-    if ethernet_connected or wifi_connected:
-        if offline_mode_enabled and not internet_available:
-            return "offline"
+    if internet_available:
         return "kiosk"
 
     if offline_mode_enabled:
+        return "offline"
+
+    if ethernet_connected or wifi_connected:
         return "offline"
 
     return "ap"

--- a/backend/tests/test_effective_mode.py
+++ b/backend/tests/test_effective_mode.py
@@ -12,13 +12,14 @@ from backend.miniweb import _determine_effective_mode
 @pytest.mark.parametrize(
     "ethernet_connected,wifi_connected,internet_available,offline_mode_enabled,expected",
     [
-        (True, False, False, True, "offline"),
         (True, False, True, True, "kiosk"),
         (True, False, True, False, "kiosk"),
-        (False, True, False, True, "offline"),
-        (False, True, False, False, "kiosk"),
+        (True, False, False, True, "offline"),
+        (True, False, False, False, "offline"),
         (False, True, True, True, "kiosk"),
         (False, True, True, False, "kiosk"),
+        (False, True, False, True, "offline"),
+        (False, True, False, False, "offline"),
         (False, False, False, True, "offline"),
         (False, False, False, False, "ap"),
     ],

--- a/src/pages/SettingsView.tsx
+++ b/src/pages/SettingsView.tsx
@@ -198,6 +198,9 @@ export const SettingsView = () => {
   const [backendNightscoutHasToken, setBackendNightscoutHasToken] = useState(false);
   const [otaStatus, setOtaStatus] = useState<OtaStatus | null>(null);
   const [isCheckingUpdates, setIsCheckingUpdates] = useState(false);
+
+  const effectiveNetworkIp = networkIP2 && networkIP2 !== "—" ? networkIP2 : networkIP;
+  const configUrlHint = effectiveNetworkIp ? `http://${effectiveNetworkIp}/config` : "http://<IP_de_la_báscula>/config";
   const [otaJobState, setOtaJobState] = useState<OtaJobState | null>(null);
   const [otaLogs, setOtaLogs] = useState("");
   const [otaPanelOpen, setOtaPanelOpen] = useState(false);
@@ -2262,6 +2265,13 @@ export const SettingsView = () => {
                   <p className="text-lg font-medium">{networkSSID}</p>
                   <p className="text-sm text-muted-foreground">{networkIP2}</p>
                 </div>
+              </div>
+
+              <div className="rounded-lg border border-primary/40 bg-primary/5 p-4">
+                <p className="text-sm text-muted-foreground">
+                  También puedes configurar Wi-Fi y claves desde otro dispositivo navegando a{' '}
+                  <span className="font-mono font-semibold text-primary">{configUrlHint}</span>.
+                </p>
               </div>
 
               {isApRecoveryMode && (


### PR DESCRIPTION
## Summary
- update the backend effective mode logic to account for internet availability and cover the new flow with tests for /api/settings
- streamline the AP provisioning UI, add an offline launch option, and avoid redundant configuration hints
- surface the remote configuration URL hint in the network settings view for users on the device

## Testing
- pytest backend/tests
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e540deed1483268ff5a9330ee8efde