### PR TITLE
Fix settings health endpoint and kiosk input UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,32 @@ La mini-web expone endpoints REST pensados para el flujo de provisión sin `sudo
 
 > El endpoint legado `/api/miniweb/connect-wifi` permanece disponible como alias para compatibilidad.
 
+## Mini-web de ajustes y API de settings
+
+La mini-web completa está disponible en `http://<IP>:8080/config` durante el modo AP y también desde la red local habitual en
+`http://<IP>/config`. Desde cualquier navegador conectado podrás introducir el PIN mostrado en la báscula y gestionar tanto la
+conexión Wi-Fi como las integraciones (OpenAI, Nightscout, modo offline, etc.).
+
+El backend expone una API específica para estos ajustes:
+
+| Método  | Endpoint                 | Descripción |
+|---------|--------------------------|-------------|
+| GET     | `/api/settings`          | Devuelve la configuración actual normalizada, incluyendo `network.status`, `ui.offline_mode` y los indicadores de credenciales almacenadas. |
+| POST    | `/api/settings`          | Persiste cambios de configuración. **Debe usarse `POST`** (no `PUT`), enviando JSON con los campos deseados. Cuando accedes desde otro dispositivo añade `Authorization: BasculaPin <PIN>` en la cabecera para autorizar la operación. |
+| OPTIONS | `/api/settings`          | Expone `Allow: GET, POST, OPTIONS` para clientes y diagnósticos. |
+| GET     | `/api/settings/health`   | Comprueba lectura/escritura del archivo de settings y responde `{ ok, can_write, message, version, updated_at }`. |
+
+Los scripts, la UI táctil y la mini-web utilizan esta misma API. Tras ejecutar `scripts/install-all.sh` puedes validar el
+comportamiento con:
+
+```bash
+curl -s http://localhost:8080/api/settings/health | jq .
+curl -s http://localhost:8080/api/settings | jq .
+curl -s -X POST http://localhost:8080/api/settings \
+  -H 'Content-Type: application/json' \
+  -d '{"ui": {"offline_mode": false}}'
+```
+
 ### Reglas de PolicyKit
 
 Las reglas instaladas permiten al usuario `pi` (o miembros de `netdev`) ejecutar `nmcli` para escanear, crear conexiones Wi-Fi y gestionar modo compartido sin `sudo`. 【F:packaging/polkit/49-nmcli.rules†L1-L13】

--- a/backend/tests/test_effective_mode.py
+++ b/backend/tests/test_effective_mode.py
@@ -12,16 +12,17 @@ from backend.miniweb import _determine_effective_mode
 @pytest.mark.parametrize(
     "ethernet_connected,wifi_connected,internet_available,offline_mode_enabled,expected",
     [
-        (True, False, True, True, "kiosk"),
+        (True, False, True, True, "offline"),
         (True, False, True, False, "kiosk"),
         (True, False, False, True, "offline"),
         (True, False, False, False, "offline"),
-        (False, True, True, True, "kiosk"),
+        (False, True, True, True, "offline"),
         (False, True, True, False, "kiosk"),
         (False, True, False, True, "offline"),
         (False, True, False, False, "offline"),
         (False, False, False, True, "offline"),
         (False, False, False, False, "ap"),
+        (False, False, True, False, "ap"),
     ],
 )
 def test_determine_effective_mode(

--- a/backend/tests/test_miniweb_settings.py
+++ b/backend/tests/test_miniweb_settings.py
@@ -1,0 +1,108 @@
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+import backend.miniweb as miniweb
+import backend.app.services.settings_service as settings_module
+from backend.app.services.settings_service import SettingsService
+
+
+@pytest.fixture()
+def miniweb_client(tmp_path: Path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    cfg_dir = tmp_path
+    pin_path = tmp_path / "miniweb_pin"
+
+    service = SettingsService(config_path)
+
+    monkeypatch.setattr(miniweb, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(miniweb, "CFG_DIR", cfg_dir)
+    monkeypatch.setattr(miniweb, "PIN_PATH", pin_path)
+    monkeypatch.setattr(miniweb, "CURRENT_PIN", "1234")
+    monkeypatch.setattr(miniweb, "_settings_ws_connections", set())
+
+    monkeypatch.setattr(settings_module, "_service_instance", None)
+
+    def _get_service(_path=None):
+        return service
+
+    monkeypatch.setattr(settings_module, "get_settings_service", _get_service)
+    monkeypatch.setattr(miniweb, "get_settings_service", _get_service)
+
+    client = TestClient(miniweb.app)
+    return client, service, config_path
+
+
+def read_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_get_settings_returns_defaults(miniweb_client):
+    client, _service, _config_path = miniweb_client
+    response = client.get("/api/settings")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "ui" in payload
+    assert payload["ui"].get("offline_mode") is False
+    assert "network" in payload
+    assert payload["network"].get("ap", {}).get("ssid") == miniweb.AP_DEFAULT_SSID
+    assert "openai" in payload and payload["openai"].get("hasKey") is False
+
+
+def test_options_settings_allows_expected_methods(miniweb_client):
+    client, _service, _config_path = miniweb_client
+    response = client.options("/api/settings")
+
+    assert response.status_code == 204
+    allow_header = response.headers.get("allow")
+    assert allow_header == "GET, POST, OPTIONS"
+
+
+def test_post_settings_accepts_authorization_header(miniweb_client):
+    client, service, config_path = miniweb_client
+
+    response = client.post(
+        "/api/settings",
+        json={"openai_api_key": "sk-test"},
+        headers={"Authorization": "BasculaPin 1234"},
+    )
+
+    assert response.status_code == 200
+    stored = read_json(config_path)
+    assert stored.get("openai_api_key") == "sk-test"
+    assert service.load().network.openai_api_key == "sk-test"
+
+
+def test_post_settings_updates_nightscout_from_diabetes_payload(miniweb_client):
+    client, service, config_path = miniweb_client
+
+    response = client.post(
+        "/api/settings",
+        json={"diabetes": {"nightscout_url": "https://example.com", "nightscout_token": "token"}},
+        headers={"Authorization": "BasculaPin 1234"},
+    )
+
+    assert response.status_code == 200
+    stored = read_json(config_path)
+    assert stored.get("nightscout_url") == "https://example.com"
+    assert stored.get("nightscout_token") == "token"
+    loaded = service.load()
+    assert loaded.diabetes.nightscout_url == "https://example.com"
+    assert loaded.diabetes.nightscout_token == "token"
+
+
+def test_settings_health_reports_ok(miniweb_client):
+    client, _service, _config_path = miniweb_client
+
+    response = client.get("/api/settings/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload.get("ok") is True
+    assert "version" in payload
+    assert "can_write" in payload


### PR DESCRIPTION
## Summary
- restore the on-screen keyboard flow in the mini web so Wi-Fi, OpenAI, and Nightscout fields open the KeyboardDialog when touched on the kiosk
- refresh the AP fallback screen to highlight the config URL, add an offline button, and trigger the kiosk to reopen when connectivity returns
- harden the settings API by surfacing GET/POST/OPTIONS support, honoring BasculaPin headers, adding a health endpoint, and covering the new logic with tests

## Testing
- pnpm lint
- pnpm test
- pytest *(fails: missing libcap development headers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e54dc7460083269945e2727179760a