### PR TITLE
Improve miniweb settings validation

### DIFF
--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -184,8 +184,8 @@ def test_post_settings_requires_pin_for_remote(api_client, tmp_path: Path, monke
 
     response = api_client.post("/api/settings", json={"ui": {"offline_mode": True}})
 
-    assert response.status_code == 401
-    assert response.json().get("detail") == "PIN requerido"
+    assert response.status_code == 403
+    assert response.json() == {"error": "pin_required"}
 
 
 def test_post_settings_accepts_valid_pin(api_client, tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary
- tighten PIN validation for remote settings operations and return consistent JSON error payloads
- accept plain-format offline_mode updates, add strict boolean coercion, and persist secret mirrors in generated payloads
- extend the miniweb settings test suite to cover PIN enforcement, plain payloads, offline toggles, and secret masking

## Testing
- PYTHONPATH=. pytest backend/tests/test_miniweb_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68e5f765fea48326a349b32daeb63670